### PR TITLE
feat: Improve documentation and fix OpenSCAD scripts

### DIFF
--- a/corkscrew_filter_merge.scad
+++ b/corkscrew_filter_merge.scad
@@ -31,8 +31,8 @@ slit_width_mm = 2;                      // The width of the slit opening.
 hex_array_layers = 1; // 0=1 cell, 1=7 cells, 2=19 cells, etc.
 
 // --- CONTROL_VARIABLES ---
-USE_HEX_ARRAY_FILTER    = 1;
-USE_SINGLE_CELL_FILTER  = 0;
+USE_HEX_ARRAY_FILTER    = true;
+USE_SINGLE_CELL_FILTER  = false;
 
 // ===============================================================
 // === Main Logic ================================================

--- a/corkscrew_filter_merge.scad
+++ b/corkscrew_filter_merge.scad
@@ -96,8 +96,8 @@ module HexArrayLayout(layers, spacing) {
             for (s = [0 : l - 1]) {
                 angle1 = a * 60;
                 angle2 = (a+1) * 60;
-                pos = l * spacing * ([(1-s/l)*cos(angle1) + (s/l)*cos(angle2)],
-                                     [(1-s/l)*sin(angle1) + (s/l)*sin(angle2)]);
+                pos = l * spacing * [(1-s/l)*cos(angle1) + (s/l)*cos(angle2),
+                                     (1-s/l)*sin(angle1) + (s/l)*sin(angle2)];
                 translate(pos) children();
             }
         }


### PR DESCRIPTION
This commit includes several improvements and bug fixes:

- The main README.md has been completely rewritten to provide a comprehensive overview of the project. It now links to the `BOM.md` and `TODO.md` files to keep the documentation atomic, as requested.

- A syntax error in `corkscrew_filter_merge.scad` has been fixed. The C-style `for` loops were replaced with the correct OpenSCAD syntax.

- A logical bug in the `HexArrayLayout` module within `corkscrew_filter_merge.scad` has been fixed. The vector calculation for positioning elements in the hexagonal array was corrected, allowing the module to generate the array as intended.