### PR TITLE
Fix incorrect relative include paths in OpenSCAD modules

### DIFF
--- a/modules/custom_couplings.scad
+++ b/modules/custom_couplings.scad
@@ -1,5 +1,5 @@
-include <modules/barbs.scad>
-include <modules/primitives.scad>
+include <barbs.scad>
+include <primitives.scad>
 // We need primitives for O-ring cutters if we want to reproduce the cartridge logic exactly.
 
 // =============================================================================

--- a/modules/filter_holder.scad
+++ b/modules/filter_holder.scad
@@ -1,7 +1,7 @@
 include <BOSL2/std.scad>
 include <BOSL2/threading.scad>
-include <modules/barbs.scad>
-include <modules/primitives.scad>
+include <barbs.scad>
+include <primitives.scad>
 
 /**
  * Module: FilterHolder

--- a/modules/inlets.scad
+++ b/modules/inlets.scad
@@ -1,4 +1,4 @@
-include <modules/barbs.scad>
+include <barbs.scad>
 
 // =============================================================================
 // --- Inlet Component Modules ---


### PR DESCRIPTION
The changes fix compilation warnings reported by OpenSCAD. The issue was that files inside the `modules/` directory were attempting to include other files in the same directory using paths prefixed with `modules/` (e.g., `include <modules/barbs.scad>`). Because OpenSCAD resolves includes relative to the current file first, this caused it to look for `modules/modules/barbs.scad`, which does not exist. The paths have been corrected to be relative (e.g., `include <barbs.scad>`).

Modified files:
- `modules/inlets.scad`
- `modules/custom_couplings.scad`
- `modules/filter_holder.scad`

---
*PR created automatically by Jules for task [2017246854474687802](https://jules.google.com/task/2017246854474687802) started by @LokiMetaSmith*