### PR TITLE
Add CUT_FOR_VISIBILITY option to inspect internal geometry

### DIFF
--- a/config.scad
+++ b/config.scad
@@ -32,6 +32,7 @@ ADD_DEBRIS_EXIT_CHANNELS = false; // NEW: If true, cuts channels for debris to e
 // --- Visual/Debug Options ---
 SHOW_O_RINGS = true;             // If true, renders red O-rings in their grooves for visualization.
 USE_TRANSLUCENCY = false;        // If true, makes certain parts semi-transparent to see internal geometry.
+CUT_FOR_VISIBILITY = false;      // If true, cuts the model in half (removes Y>0) to allow inspection of internal geometry.
 
 // =============================================================================
 // --- B. Model Parameters ---

--- a/corkscrew.scad
+++ b/corkscrew.scad
@@ -23,38 +23,50 @@ include <modules/filter_holder.scad>
 // This block acts as the main program, calling the correct top-level assembly module
 // based on the `part_to_generate` variable set in `config.scad`.
 
-if (part_to_generate == "modular_filter_assembly") {
-    tube_id = tube_od_mm - (2 * tube_wall_mm);
-    if (GENERATE_CFD_VOLUME) {
-        difference() {
-            cylinder(d = tube_id, h = insert_length_mm, center = true);
+module GenerateSelectedPart() {
+    if (part_to_generate == "modular_filter_assembly") {
+        tube_id = tube_od_mm - (2 * tube_wall_mm);
+        if (GENERATE_CFD_VOLUME) {
+            difference() {
+                cylinder(d = tube_id, h = insert_length_mm, center = true);
+                ModularFilterAssembly(tube_id, insert_length_mm);
+            }
+        } else {
             ModularFilterAssembly(tube_id, insert_length_mm);
         }
+    } else if (part_to_generate == "hex_array_filter") {
+        HexFilterArray(hex_array_layers);
+    } else if (part_to_generate == "single_cell_filter") {
+        SingleCellFilter();
+    } else if (part_to_generate == "hose_adapter_cap") {
+        HoseAdapterEndCap(tube_od_mm, adapter_hose_id_mm, oring_cross_section_mm);
+    } else if (part_to_generate == "flat_end_screw") {
+        total_twist = 360 * number_of_complete_revolutions;
+        FlatEndScrew(insert_length_mm, total_twist, num_bins);
+    } else if (part_to_generate == "custom_coupling") {
+        CustomCoupling();
+    } else if (part_to_generate == "filter_holder") {
+        FilterHolder(
+            tube_id = tube_od_mm - (2 * tube_wall_mm),
+            cartridge_od = filter_holder_cartridge_od,
+            barb_od = barb_inlet_id_mm + 1.5, // reuse barb inlet param or add specific one
+            barb_id = barb_inlet_id_mm,
+            thread_inner = filter_holder_thread_inner,
+            thread_outer = filter_holder_thread_outer,
+            oring_cs = oring_cross_section_mm
+        );
     } else {
-        ModularFilterAssembly(tube_id, insert_length_mm);
+        echo("Error: `part_to_generate` variable is not set to a valid option.");
+        echo("Please check `config.scad` and choose from the `part_options` list.");
     }
-} else if (part_to_generate == "hex_array_filter") {
-    HexFilterArray(hex_array_layers);
-} else if (part_to_generate == "single_cell_filter") {
-    SingleCellFilter();
-} else if (part_to_generate == "hose_adapter_cap") {
-    HoseAdapterEndCap(tube_od_mm, adapter_hose_id_mm, oring_cross_section_mm);
-} else if (part_to_generate == "flat_end_screw") {
-    total_twist = 360 * number_of_complete_revolutions;
-    FlatEndScrew(insert_length_mm, total_twist, num_bins);
-} else if (part_to_generate == "custom_coupling") {
-    CustomCoupling();
-} else if (part_to_generate == "filter_holder") {
-    FilterHolder(
-        tube_id = tube_od_mm - (2 * tube_wall_mm),
-        cartridge_od = filter_holder_cartridge_od,
-        barb_od = barb_inlet_id_mm + 1.5, // reuse barb inlet param or add specific one
-        barb_id = barb_inlet_id_mm,
-        thread_inner = filter_holder_thread_inner,
-        thread_outer = filter_holder_thread_outer,
-        oring_cs = oring_cross_section_mm
-    );
+}
+
+if (CUT_FOR_VISIBILITY) {
+    difference() {
+        GenerateSelectedPart();
+        // Cut away the front half (positive Y)
+        translate([-500, 0, -500]) cube([1000, 1000, 1000]);
+    }
 } else {
-    echo("Error: `part_to_generate` variable is not set to a valid option.");
-    echo("Please check `config.scad` and choose from the `part_options` list.");
+    GenerateSelectedPart();
 }


### PR DESCRIPTION
Introduced a `CUT_FOR_VISIBILITY` flag in `config.scad`. When set to true, `corkscrew.scad` renders the selected part with a boolean difference operation that removes the front half (positive Y) of the model. This allows for visual inspection of internal features such as helical channels and infill structures.

Refactored the part generation logic in `corkscrew.scad` into a `GenerateSelectedPart()` module to facilitate this conditional operation.