### PR TITLE
Fix barb geometry, gap, and inlet alignment

### DIFF
--- a/modules/assemblies.scad
+++ b/modules/assemblies.scad
@@ -58,10 +58,17 @@ module ModularFilterAssembly(tube_id, total_length) {
                                     recess_d = (inlet_type == "threaded" || inlet_type == "pressfit")
                                         ? threaded_inlet_flange_od + tolerance_socket_fit
                                         : barb_inlet_flange_od + tolerance_socket_fit;
+
+                                    is_barb = (inlet_type == "barb");
+                                    rz = is_top ? (spacer_height_mm / 2 - 1) : (-spacer_height_mm / 2 + 2);
+                                    ra = twist_rate * rz;
+                                    rx = is_barb ? helix_path_radius_mm * cos(ra) : 0;
+                                    ry = is_barb ? helix_path_radius_mm * sin(ra) : 0;
+
                                     if (is_top) {
-                                        translate([0, 0, spacer_height_mm / 2 - 1]) cylinder(d = recess_d, h = 2);
+                                        translate([rx, ry, spacer_height_mm / 2 - 1]) cylinder(d = recess_d, h = 2);
                                     } else { // is_base
-                                        translate([0, 0, -spacer_height_mm / 2]) cylinder(d = recess_d, h = 2);
+                                        translate([rx, ry, -spacer_height_mm / 2]) cylinder(d = recess_d, h = 2);
                                     }
                                 }
                             }
@@ -69,11 +76,15 @@ module ModularFilterAssembly(tube_id, total_length) {
 
                         if ((is_top || is_base) && inlet_type != "none") {
                             mirror_vec = [0, 0, is_top ? 0 : 1];
-                            z_shift = is_top ? spacer_height_mm / 2 : -spacer_height_mm / 2;
                             if (inlet_type == "threaded" || inlet_type == "pressfit") {
+                                z_shift = is_top ? spacer_height_mm / 2 : -spacer_height_mm / 2;
                                 translate([0, 0, z_shift]) mirror(mirror_vec) ThreadedInlet();
                             } else if (inlet_type == "barb") {
-                                translate([0, 0, z_shift]) mirror(mirror_vec) BarbInlet();
+                                z_local = is_top ? (spacer_height_mm / 2 - 1) : (-spacer_height_mm / 2 + 2);
+                                angle_local = twist_rate * z_local;
+                                x_off = helix_path_radius_mm * cos(angle_local);
+                                y_off = helix_path_radius_mm * sin(angle_local);
+                                translate([x_off, y_off, z_local]) mirror(mirror_vec) BarbInlet();
                             }
                         }
 

--- a/modules/barbs.scad
+++ b/modules/barbs.scad
@@ -39,7 +39,7 @@ module Barb(
             if (shell) {
                 for (z = [0 : barb_count - 1]) {
                     translate([0, 0, z * barb_length])
-                        cylinder(d1 = hose_od, d2 = hose_od + swell, h = barb_length, $fn = $fn);
+                        cylinder(d1 = hose_od + swell, d2 = hose_od, h = barb_length, $fn = $fn);
                 }
                  translate([0, 0, barb_count * barb_length])
                      cylinder(d = hose_od, h = barb_length, $fn = $fn); // Simple tip


### PR DESCRIPTION
This PR addresses three issues reported by the user:
1.  **Barbs going the wrong way:** The `Barb` module was generating cones that widened upwards, creating undercuts that would block hose insertion. This was fixed by swapping `d1` and `d2` to create a proper ramp.
2.  **Gap under the shoulder:** The `BarbInlet` was sitting on the spacer face while the recess was cut into the spacer, leaving a gap or misalignment. The `BarbInlet` is now translated into the recess to sit flush.
3.  **Corkscrew diameter mismatch:** The `BarbInlet` was centered, but the helical channel inside the spacer is offset and rotating. This misalignment caused the connection to be choked (small intersection area). The code now calculates the helix position at the inlet's Z-height and aligns the inlet (and its recess) to the helix, ensuring a full-diameter connection.

---
*PR created automatically by Jules for task [6667579549806968374](https://jules.google.com/task/6667579549806968374) started by @LokiMetaSmith*