### PR TITLE
Add axial seal option for hose adapter cap

### DIFF
--- a/config.scad
+++ b/config.scad
@@ -69,6 +69,7 @@ support_density = 4;             // The number of support bundles distributed ar
 adapter_hose_id_mm = 30;         // The inner diameter of the hose that will connect to the end cap adapter.
 flange_od = 20;                  // The outer diameter of the flange on the hose adapter.
 flange_height = 5;               // The height of the flange on the hose adapter.
+ADAPTER_AXIAL_SEAL = false;      // If true, uses an axial (face) seal with a cup for the tube. If false, uses a radial seal.
 
 // --- Inlet Parameters (for Modular Filter) ---
 // Threaded Inlet

--- a/corkscrew.scad
+++ b/corkscrew.scad
@@ -39,7 +39,7 @@ module GenerateSelectedPart() {
     } else if (part_to_generate == "single_cell_filter") {
         SingleCellFilter();
     } else if (part_to_generate == "hose_adapter_cap") {
-        HoseAdapterEndCap(tube_od_mm, adapter_hose_id_mm, oring_cross_section_mm);
+        HoseAdapterEndCap(tube_od_mm, adapter_hose_id_mm, oring_cross_section_mm, tube_wall_mm, ADAPTER_AXIAL_SEAL);
     } else if (part_to_generate == "flat_end_screw") {
         total_twist = 360 * number_of_complete_revolutions;
         FlatEndScrew(insert_length_mm, total_twist, num_bins);

--- a/modules/primitives.scad
+++ b/modules/primitives.scad
@@ -55,6 +55,19 @@ module OringGroove_ID_Cutter(object_id, oring_cs) {
     rotate_extrude(convexity = 10) translate([object_id / 2 + groove_depth / 2, 0, 0]) square([groove_depth, groove_width], center = true);
 }
 
+/**
+ * Module: OringGroove_Face_Cutter
+ * Description: Creates a cutting tool for an O-ring groove on a flat face (Z-axis).
+ * Arguments:
+ * groove_center_dia: The diameter of the center of the groove.
+ * oring_cs:   The cross-section diameter of the O-ring.
+ */
+module OringGroove_Face_Cutter(groove_center_dia, oring_cs) {
+    groove_depth = oring_cs * 0.8;
+    groove_width = oring_cs * 1.1;
+    rotate_extrude(convexity = 10) translate([groove_center_dia / 2, 0, 0]) square([groove_width, groove_depth], center = true);
+}
+
 
 // --- Barb Primitives (from BarbGenerator-v3.scad by jsc, corrected implementation) ---
 


### PR DESCRIPTION
This change adds a new configuration option `ADAPTER_AXIAL_SEAL` to allow the generation of a hose adapter end cap with an axial (face) O-ring seal instead of the default radial seal. The new geometry features a double-walled cup (socket) for the tube to rest against, with an O-ring groove on the bottom face of the socket. This ensures better sealing and stability for certain tube connections.

---
*PR created automatically by Jules for task [14154372937926612279](https://jules.google.com/task/14154372937926612279) started by @LokiMetaSmith*