### PR TITLE
Add STL export script for configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ corkscrewFilter/processor*/
 corkscrewFilter/postProcessing/
 corkscrewFilter/log.*
 optimizer/venv/
+exports/

--- a/configs/filter_holder.scad
+++ b/configs/filter_holder.scad
@@ -1,0 +1,3 @@
+include <../config.scad>
+part_to_generate = "filter_holder";
+include <../corkscrew.scad>

--- a/configs/flat_end_screw.scad
+++ b/configs/flat_end_screw.scad
@@ -1,0 +1,3 @@
+include <../config.scad>
+part_to_generate = "flat_end_screw";
+include <../corkscrew.scad>

--- a/configs/hex_array_filter.scad
+++ b/configs/hex_array_filter.scad
@@ -1,0 +1,3 @@
+include <../config.scad>
+part_to_generate = "hex_array_filter";
+include <../corkscrew.scad>

--- a/configs/hose_adapter_cap.scad
+++ b/configs/hose_adapter_cap.scad
@@ -1,0 +1,3 @@
+include <../config.scad>
+part_to_generate = "hose_adapter_cap";
+include <../corkscrew.scad>

--- a/configs/modular_filter_assembly.scad
+++ b/configs/modular_filter_assembly.scad
@@ -1,0 +1,3 @@
+include <../config.scad>
+part_to_generate = "modular_filter_assembly";
+include <../corkscrew.scad>

--- a/configs/single_cell_filter.scad
+++ b/configs/single_cell_filter.scad
@@ -1,0 +1,3 @@
+include <../config.scad>
+part_to_generate = "single_cell_filter";
+include <../corkscrew.scad>

--- a/export_configs.py
+++ b/export_configs.py
@@ -1,0 +1,59 @@
+import os
+import subprocess
+import glob
+import sys
+
+def main():
+    source_dir = "configs"
+    output_dir = "exports"
+
+    # Create output directory if it doesn't exist
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+        print(f"Created output directory: {output_dir}")
+
+    # Find all SCAD files in the configs directory
+    scad_files = glob.glob(os.path.join(source_dir, "*.scad"))
+
+    if not scad_files:
+        print(f"No .scad files found in {source_dir}")
+        return
+
+    print(f"Found {len(scad_files)} configuration files to export.")
+
+    success_count = 0
+    fail_count = 0
+
+    for scad_file in scad_files:
+        filename = os.path.basename(scad_file)
+        name_no_ext = os.path.splitext(filename)[0]
+        output_file = os.path.join(output_dir, f"{name_no_ext}.stl")
+
+        print(f"\nProcessing: {scad_file} -> {output_file}")
+
+        cmd = ["openscad", "-o", output_file, scad_file]
+
+        try:
+            print(f"Executing: {' '.join(cmd)}")
+            result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+            print("Success!")
+            success_count += 1
+        except subprocess.CalledProcessError as e:
+            print(f"Error exporting {scad_file}:")
+            print(f"Return code: {e.returncode}")
+            print(f"Stderr: {e.stderr}")
+            fail_count += 1
+        except FileNotFoundError:
+            print("Error: 'openscad' executable not found. Please install OpenSCAD and ensure it is in your PATH.")
+            # If openscad is missing, no point in trying the rest
+            sys.exit(1)
+        except Exception as e:
+            print(f"An unexpected error occurred: {e}")
+            fail_count += 1
+
+    print("\n--- Export Summary ---")
+    print(f"Successfully exported: {success_count}")
+    print(f"Failed: {fail_count}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Added a Python script `export_configs.py` that automates the process of converting OpenSCAD configuration files in the `configs/` directory to STL format using the `openscad` command line tool. The script creates an `exports/` directory for the output and handles missing executable errors gracefully. Also updated `.gitignore` to exclude the generated `exports/` directory.

---
*PR created automatically by Jules for task [10272014527864871352](https://jules.google.com/task/10272014527864871352) started by @LokiMetaSmith*