### PR TITLE
Fix HoseAdapterEndCap missing barb

### DIFF
--- a/modules/assemblies.scad
+++ b/modules/assemblies.scad
@@ -239,7 +239,7 @@ module HoseAdapterEndCap(tube_od, hose_id, oring_cs, tube_wall = tube_wall_mm, a
         }
 
         translate([0, 0, cap_sleeve_height + cap_end_plate_thick + flange_height])
-            barb(hose_id, 4);
+            Barb(hose_id = hose_id, hose_od = hose_id + 1.5, barb_count = 4);
 
     } else {
         // --- Legacy Radial Seal Geometry ---
@@ -259,6 +259,6 @@ module HoseAdapterEndCap(tube_od, hose_id, oring_cs, tube_wall = tube_wall_mm, a
             translate([0, 0, cap_sleeve_height]) cylinder(d = hose_id, h = cap_end_plate_thick + flange_height + 2);
         }
         translate([0, 0, cap_sleeve_height + cap_end_plate_thick + flange_height])
-            barb(hose_id, 4);
+            Barb(hose_id = hose_id, hose_od = hose_id + 1.5, barb_count = 4);
     }
 }


### PR DESCRIPTION
Replaced legacy `barb()` call with `Barb()` in `HoseAdapterEndCap` within `modules/assemblies.scad`. This fixes the issue where the barb was either missing or using incorrect geometry. Verified that the user's reported configuration was selecting `FilterHolder` (Index 5) instead of `HoseAdapterEndCap` (Index 3), which explained the unexpected output in their image.

---
*PR created automatically by Jules for task [6709142268274067415](https://jules.google.com/task/6709142268274067415) started by @LokiMetaSmith*