### PR TITLE
Add threaded modular filter configuration and functional threads

### DIFF
--- a/configs/threaded_modular_filter_pipe.scad
+++ b/configs/threaded_modular_filter_pipe.scad
@@ -1,0 +1,15 @@
+// Threaded Modular Filter & Pipe Configuration
+// Configures the modular filter with threaded inlets and standard pipe dimensions.
+include <../config.scad>
+
+// Enable Modular Filter
+part_to_generate = "modular_filter_assembly";
+
+// Enable Threaded Inlets
+inlet_type = "threaded";
+
+// Pipe/Tube Configuration (Matches BOM Standard: 32mm OD / 30mm ID)
+tube_od_mm = 32;
+tube_wall_mm = 1;
+
+include <../corkscrew.scad>

--- a/modules/inlets.scad
+++ b/modules/inlets.scad
@@ -1,3 +1,5 @@
+include <BOSL2/std.scad>
+include <BOSL2/threading.scad>
 include <barbs.scad>
 
 // =============================================================================
@@ -9,17 +11,16 @@ include <barbs.scad>
 /**
  * Module: ThreadedInlet
  * Description: Creates a threaded inlet piece with a flange, designed to be added to an end spacer.
- * Note: This creates a cosmetic thread; for a functional thread, replace the inner
- * cylinder with a proper thread library module.
+ * Note: This creates a functional thread using BOSL2 threaded_rod.
  */
 module ThreadedInlet() {
     flange_height = 2;
     difference() {
         union() {
-            cylinder(d = threaded_inlet_id_mm, h = threaded_inlet_height);
+            threaded_rod(d = threaded_inlet_id_mm, l = threaded_inlet_height, pitch = 1, anchor = BOTTOM, $fn=$fn);
             cylinder(d = threaded_inlet_flange_od, h = flange_height);
         }
-        translate([0, 0, -1])
+        down(1)
             cylinder(d = threaded_inlet_id_mm - 2, h = threaded_inlet_height + 2);
     }
 }


### PR DESCRIPTION
Created configs/threaded_modular_filter_pipe.scad to export a modular filter with threaded inlets and standard 32mm pipe dimensions. Upgraded modules/inlets.scad to use BOSL2 for functional threading in ThreadedInlet.

---
*PR created automatically by Jules for task [4497640004359105061](https://jules.google.com/task/4497640004359105061) started by @LokiMetaSmith*