### PR TITLE
Increase high_res_fn to 200 for smoother renders

### DIFF
--- a/config.scad
+++ b/config.scad
@@ -39,7 +39,7 @@ CUT_FOR_VISIBILITY = false;      // If true, cuts the model in half (removes Y>0
 // =============================================================================
 
 // --- General & Precision ---
-high_res_fn = 10; // Fragment resolution for final renders ($fn). Higher values create smoother curves.
+high_res_fn = 200; // Fragment resolution for final renders ($fn). Higher values create smoother curves.
 low_res_fn = 10;   // Fragment resolution for previews. Lower values provide faster previews.
 $fn = $preview ? low_res_fn : high_res_fn; // OpenSCAD automatically uses the appropriate value.
 


### PR DESCRIPTION
Updated `config.scad` to increase `high_res_fn` from 10 to 200. This ensures that final renders (F6) produce smoother curved surfaces for 3D printing, addressing the user's concern about low resolution. Preview resolution remains unchanged at 10 for performance.

---
*PR created automatically by Jules for task [3886078540645389462](https://jules.google.com/task/3886078540645389462) started by @LokiMetaSmith*