### PR TITLE
Add O-ring visualization to all filter components

### DIFF
--- a/modules/assemblies.scad
+++ b/modules/assemblies.scad
@@ -182,6 +182,17 @@ module HexFilterArray(layers) {
         HexArrayLayout(layers, spacing) {
             StagedHelicalStructure(cell_length, cell_diameter, num_helices, num_stages);
         }
+
+        if (ADD_OUTER_O_RINGS && SHOW_O_RINGS) {
+            for (a = [0:5]) {
+                rotate([0, 0, a * 60 + 30]) {
+                    translate([hex_casing_radius / 2, 0, cell_length / 4])
+                        OringVisualizer_Linear(hex_casing_radius, oring_cross_section_mm);
+                    translate([hex_casing_radius / 2, 0, -cell_length / 4])
+                        OringVisualizer_Linear(hex_casing_radius, oring_cross_section_mm);
+                }
+            }
+        }
     }
 }
 
@@ -238,6 +249,12 @@ module HoseAdapterEndCap(tube_od, hose_id, oring_cs, tube_wall = tube_wall_mm, a
             translate([0, 0, cap_sleeve_height - groove_depth / 2]) OringGroove_Face_Cutter(groove_center_dia, oring_cs);
         }
 
+        if (SHOW_O_RINGS) {
+            groove_depth = oring_cs * 0.8;
+            groove_center_dia = (socket_od + socket_id) / 2;
+            translate([0, 0, cap_sleeve_height - groove_depth / 2]) OringVisualizer_Face(groove_center_dia, oring_cs);
+        }
+
         translate([0, 0, cap_sleeve_height + cap_end_plate_thick + flange_height])
             Barb(hose_id = hose_id, hose_od = hose_id + 1.5, barb_count = 4);
 
@@ -258,6 +275,11 @@ module HoseAdapterEndCap(tube_od, hose_id, oring_cs, tube_wall = tube_wall_mm, a
             translate([0, 0, cap_sleeve_height / 2]) OringGroove_ID_Cutter(cap_inner_dia, oring_cs);
             translate([0, 0, cap_sleeve_height]) cylinder(d = hose_id, h = cap_end_plate_thick + flange_height + 2);
         }
+
+        if (SHOW_O_RINGS) {
+            translate([0, 0, cap_sleeve_height / 2]) OringVisualizer_ID(cap_inner_dia, oring_cs);
+        }
+
         translate([0, 0, cap_sleeve_height + cap_end_plate_thick + flange_height])
             Barb(hose_id = hose_id, hose_od = hose_id + 1.5, barb_count = 4);
     }

--- a/modules/custom_couplings.scad
+++ b/modules/custom_couplings.scad
@@ -47,6 +47,15 @@ module CustomCoupling() {
         }
     }
 
+    if (custom_coupling_type == "cartridge" && SHOW_O_RINGS) {
+        translate([0,0,(coupling_inset_height+coupling_lip_height)*4/5])
+            OringVisualizer(coupling_inset_width, 2.2);
+        translate([0,0,(coupling_inset_height+coupling_lip_height)/2])
+            OringVisualizer(coupling_inset_width, 2.2);
+        translate([0,0,(coupling_inset_height+coupling_lip_height)/4])
+            OringVisualizer(coupling_inset_width, 2.2);
+    }
+
     // --- Barb Attachment ---
     translate([0,0,-(coupling_outer_coupling_height+coupling_lip_height/2)])
         translate([0,0,0.09])

--- a/modules/filter_holder.scad
+++ b/modules/filter_holder.scad
@@ -133,6 +133,17 @@ module FilterHolder(
                 // 4. Clear center flow path (for entire height)
                  translate([0,0,-1]) cylinder(d = barb_id, h = lip_height + 2, $fn=$fn);
             }
+
+            // --- VISUALIZATION ---
+            if (SHOW_O_RINGS) {
+                 // Outer O-Ring
+                 translate([0,0,segment_h + segment_h/2])
+                    OringVisualizer(outer_seal_od, oring_cs);
+
+                 // Inner O-Ring
+                 translate([0,0,segment_h + segment_h/2])
+                    OringVisualizer_ID(inner_seal_id, oring_cs);
+            }
         }
     }
 }

--- a/modules/primitives.scad
+++ b/modules/primitives.scad
@@ -31,7 +31,7 @@ module OringGroove_OD_Cutter(object_dia, oring_cs, flat = false) {
 
 /**
  * Module: OringVisualizer
- * Description: Renders a torus shape to represent an O-ring for visualization purposes.
+ * Description: Renders a torus shape to represent an O-ring for visualization purposes (Outer Diameter).
  * Arguments:
  * object_dia: The diameter of the object the O-ring sits on.
  * oring_cs:   The cross-section diameter of the O-ring.
@@ -41,6 +41,49 @@ module OringVisualizer(object_dia, oring_cs) {
     torus_radius = object_dia / 2 - groove_depth / 2;
     color("IndianRed") rotate_extrude(convexity = 10) translate([torus_radius, 0, 0]) circle(r = oring_cs / 2);
 }
+
+/**
+ * Module: OringVisualizer_ID
+ * Description: Renders a torus shape to represent an O-ring for visualization purposes (Inner Diameter).
+ * Arguments:
+ * object_id: The inner diameter of the object the O-ring sits in.
+ * oring_cs:  The cross-section diameter of the O-ring.
+ */
+module OringVisualizer_ID(object_id, oring_cs) {
+    groove_depth = oring_cs * 0.8;
+    torus_radius = object_id / 2 + groove_depth / 2;
+    color("IndianRed") rotate_extrude(convexity = 10) translate([torus_radius, 0, 0]) circle(r = oring_cs / 2);
+}
+
+/**
+ * Module: OringVisualizer_Face
+ * Description: Renders a torus shape to represent an O-ring for visualization purposes (Axial/Face Seal).
+ * Arguments:
+ * groove_center_dia: The diameter of the center of the groove.
+ * oring_cs:   The cross-section diameter of the O-ring.
+ */
+module OringVisualizer_Face(groove_center_dia, oring_cs) {
+    color("IndianRed") rotate_extrude(convexity = 10) translate([groove_center_dia / 2, 0, 0]) circle(r = oring_cs / 2);
+}
+
+/**
+ * Module: OringVisualizer_Linear
+ * Description: Renders a cylinder/capsule shape to represent a linear O-ring seal.
+ * Arguments:
+ * length:     The length of the seal (matches object_dia in OringGroove_OD_Cutter with flat=true).
+ * oring_cs:   The cross-section diameter of the O-ring.
+ */
+module OringVisualizer_Linear(length, oring_cs) {
+    groove_depth = oring_cs * 0.8;
+    // The cutter is a cube extending from Z=0 to Z=groove_depth.
+    // The O-ring sits "in" the groove, centered at half depth?
+    // Usually O-rings are compressed. If we visualize it uncompressed, it might stick out.
+    // Let's center it at groove_depth / 2, so it's flush with the bottom of the groove
+    // but sticks out the top by (cs/2 - groove_depth/2).
+    // Center Z = groove_depth / 2.
+    color("IndianRed") translate([0, 0, groove_depth / 2]) rotate([0, 90, 0]) cylinder(h = length, d = oring_cs, center = true);
+}
+
 
 /**
  * Module: OringGroove_ID_Cutter


### PR DESCRIPTION
This change implements the requested O-ring visualization improvements across the codebase. It adds new primitive modules for visualizing internal, face, and linear O-ring seals and integrates them into the `HoseAdapterEndCap`, `FilterHolder`, `CustomCoupling`, and `HexFilterArray` modules. The visualization is controlled by the `SHOW_O_RINGS` global variable.

---
*PR created automatically by Jules for task [1984248320318634875](https://jules.google.com/task/1984248320318634875) started by @LokiMetaSmith*