### PR TITLE
Refactor FilterHolder for Face Seals and Correct Threading

### DIFF
--- a/corkscrew.scad
+++ b/corkscrew.scad
@@ -53,7 +53,8 @@ module GenerateSelectedPart() {
             barb_id = barb_inlet_id_mm,
             thread_inner = filter_holder_thread_inner,
             thread_outer = filter_holder_thread_outer,
-            oring_cs = oring_cross_section_mm
+            oring_cs = oring_cross_section_mm,
+            tube_wall = tube_wall_mm
         );
     } else {
         echo("Error: `part_to_generate` variable is not set to a valid option.");


### PR DESCRIPTION
This PR addresses issues with the `FilterHolder` module where threads were positioned incorrectly (at the tip) for standard fittings, and seals were radial, preventing proper mating with threaded pipes or cartridges that require a face seal.

Changes:
- Modified `corkscrew.scad` to pass `tube_wall_mm` to `FilterHolder`.
- Modified `modules/filter_holder.scad`:
    - Added `tube_wall` parameter.
    - Updated `base_plate_od` to create a flange (`tube_id + 2*wall`) when `thread_outer` is true.
    - Implemented Face Seal logic using `OringGroove_Face_Cutter`.
    - Swapped Thread/Seal segment positions on lips: Threads are now Proximal (Base), Smooth Pilot is Distal (Tip).
    - Corrected groove centering math.

---
*PR created automatically by Jules for task [2466369862218421285](https://jules.google.com/task/2466369862218421285) started by @LokiMetaSmith*