### PR TITLE
Fix FilterHolder O-ring visualization and reinforce central bore

### DIFF
--- a/modules/filter_holder.scad
+++ b/modules/filter_holder.scad
@@ -175,18 +175,34 @@ module FilterHolder(
                 }
 
                 // 4. Clear center flow path (for entire height)
-                 translate([0,0,-1]) cylinder(d = barb_id, h = lip_height + 2, $fn=$fn);
+                // Extend upwards to ensure overlap with base plate hole
+                 translate([0,0,-1]) cylinder(d = barb_id, h = lip_height + 50, $fn=$fn);
             }
 
             // --- VISUALIZATION ---
             if (SHOW_O_RINGS) {
-                 // Outer O-Ring
-                 translate([0,0,segment_h + segment_h/2])
-                    OringVisualizer(outer_seal_od, oring_cs);
+                 if (thread_outer) {
+                      // Face Seal Visualization (Outer)
+                      // Sits on the underside of the base plate (Global Z=0)
+                      rim_center = base_plate_od - oring_cs;
+                      translate([0, 0, lip_height])
+                          OringVisualizer_Face(rim_center, oring_cs);
+                 } else {
+                     // Outer O-Ring (Radial)
+                     translate([0,0,segment_h + segment_h/2])
+                        OringVisualizer(outer_seal_od, oring_cs);
+                 }
 
-                 // Inner O-Ring
-                 translate([0,0,segment_h + segment_h/2])
-                    OringVisualizer_ID(inner_seal_id, oring_cs);
+                 if (thread_inner) {
+                     // Face Seal Visualization (Inner)
+                     // Sits on the underside of the base plate (Global Z=0)
+                     translate([0, 0, lip_height])
+                        OringVisualizer_Face(cartridge_od, oring_cs);
+                 } else {
+                     // Inner O-Ring (Radial)
+                     translate([0,0,segment_h + segment_h/2])
+                        OringVisualizer_ID(inner_seal_id, oring_cs);
+                 }
             }
         }
     }


### PR DESCRIPTION
This PR addresses two issues in `FilterHolder`:
1. **Visualization Artifact:** When `thread_outer=true`, the radial O-ring visualizer was incorrectly rendered inside the external threads, creating a "wavy" illusion and confusing geometry. The code now correctly switches to a Face Seal visualizer (`OringVisualizer_Face`) when external threads are active.
2. **Blocked Airflow:** Reports of "no center shaft" or blocked airflow were addressed by significantly extending the height of the central subtraction cylinder (`lip_height + 50`) to guarantee it fully penetrates the base plate and barb union, regardless of tolerance or minor parameter changes.

---
*PR created automatically by Jules for task [4371993514452188356](https://jules.google.com/task/4371993514452188356) started by @LokiMetaSmith*