### PR TITLE
Add Colors to FilterHolder

### DIFF
--- a/modules/filter_holder.scad
+++ b/modules/filter_holder.scad
@@ -47,6 +47,7 @@ module FilterHolder(
     union() {
         // 1. Central Barb
         translate([0, 0, base_height])
+        color("Blue", 1.0)
         Barb(
             hose_id = barb_id,
             hose_od = barb_od,
@@ -57,7 +58,7 @@ module FilterHolder(
 
         // 2. Main Body Plate
         difference() {
-            cylinder(d = base_plate_od, h = base_height, $fn=$fn);
+            color("Chartreuse", 1.0) cylinder(d = base_plate_od, h = base_height, $fn=$fn);
             // Center hole for flow
             translate([0,0,-1]) cylinder(d = barb_id, h = base_height + 2, $fn=$fn);
 
@@ -84,17 +85,17 @@ module FilterHolder(
                     // --- OUTER LIP CONSTRUCTION ---
                     if (thread_outer) {
                         // Thread the entire length
-                        threaded_rod(d=outer_seal_od, h=lip_height, pitch=1.5, internal=false, $fn=$fn);
+                        color("Orange", 1.0) threaded_rod(d=outer_seal_od, h=lip_height, pitch=1.5, internal=false, $fn=$fn);
                     } else {
                         // Smooth Seal - Top Segment
                         translate([0,0,segment_h]) {
-                             difference() {
+                             color("Orange", 1.0) difference() {
                                 cylinder(d = outer_seal_od, h = segment_h, $fn=$fn);
                                 translate([0,0,-1]) cylinder(d = outer_seal_od - 4, h = segment_h+2, $fn=$fn);
                             }
                         }
                         // Smooth Seal - Bottom Segment
-                        difference() {
+                        color("Gold", 1.0) difference() {
                             cylinder(d = outer_seal_od, h = segment_h, $fn=$fn);
                             translate([0,0,-1]) cylinder(d = outer_seal_od - 4, h = segment_h+2, $fn=$fn);
                         }
@@ -104,17 +105,17 @@ module FilterHolder(
                     // Top Segment (Proximal/Base) - z=5 to 10
                     translate([0,0,segment_h]) {
                          // Provide material
-                         cylinder(d = inner_seal_id + 4, h = segment_h, $fn=$fn);
+                         color("Cyan", 1.0) cylinder(d = inner_seal_id + 4, h = segment_h, $fn=$fn);
                     }
 
                     // Bottom Segment (Distal/Tip) - z=0 to 5
                     // Provide material
-                    cylinder(d = inner_seal_id + 4, h = segment_h, $fn=$fn);
+                    color("Purple", 1.0) cylinder(d = inner_seal_id + 4, h = segment_h, $fn=$fn);
 
 
                     // Connecting Base (overlap with main body to ensure solid)
                     translate([0,0,lip_height-1])
-                        cylinder(d = outer_seal_od, h = 1, $fn=$fn);
+                        color("Magenta", 1.0) cylinder(d = outer_seal_od, h = 1, $fn=$fn);
                 }
 
                 // --- SUBTRACTIONS (Holes, Threads, O-Rings) ---


### PR DESCRIPTION
Applied distinct colors to the sub-components of `modules/filter_holder.scad` (Barb, Main Body, Outer Lip, Inner Lip) to facilitate visual identification of code blocks in OpenSCAD. Verified geometry generation using `export.js`. Note: Colors are not visible in STL-based exports.

---
*PR created automatically by Jules for task [18272094725854962691](https://jules.google.com/task/18272094725854962691) started by @LokiMetaSmith*