### PR TITLE
Fix BOSL2 include path in WASM export

### DIFF
--- a/export.js
+++ b/export.js
@@ -183,7 +183,9 @@ async function main() {
         }
 
         // Mount Project Files
-        loadDir(instance, LIB_DIR, '/BOSL2');
+        // Ensure /libraries exists for standard library path resolution
+        try { instance.FS.mkdir('/libraries'); } catch(e) {}
+        loadDir(instance, LIB_DIR, '/libraries/BOSL2');
         loadDir(instance, 'modules', '/modules');
         loadDir(instance, 'parameters', '/parameters');
 


### PR DESCRIPTION
Fixed an issue where OpenSCAD WASM exports failed because BOSL2 was mounted to the root directory, causing `include <BOSL2/...>` to fail for files in subdirectories (which rely on standard library search paths).

Changes:
- Modified `export.js` to create `/libraries` and mount `BOSL2` to `/libraries/BOSL2`.
- Verified using a reproduction script and regression tests.

---
*PR created automatically by Jules for task [8584905133966276084](https://jules.google.com/task/8584905133966276084) started by @LokiMetaSmith*