### PR TITLE
Add timestamps to optimizer logs

### DIFF
--- a/optimizer/utils.py
+++ b/optimizer/utils.py
@@ -2,6 +2,8 @@ import subprocess
 import sys
 import time
 import os
+import datetime
+import threading
 
 class Timer:
     def __init__(self, description=None):
@@ -24,28 +26,48 @@ class Timer:
 
 def run_command_with_spinner(cmd, log_file_path, cwd=None, description="Processing"):
     """
-    Runs a command, streaming output to a log file, while showing a spinner on the console.
+    Runs a command, streaming output to a log file with timestamps, while showing a spinner on the console.
     """
     # Ensure directory for log file exists
     log_dir = os.path.dirname(log_file_path)
     if log_dir:
         os.makedirs(log_dir, exist_ok=True)
 
+    # Use a thread to read output and write to log
+    # We open the file in append mode.
+    # Note: process.stdout will be text mode (text=True)
+
     with open(log_file_path, "a") as log_f:
-        log_f.write(f"\n# Executing: {' '.join(cmd)}\n")
+        timestamp = datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S] ")
+        log_f.write(f"\n{timestamp}# Executing: {' '.join(cmd)}\n")
         log_f.flush()
 
         try:
             process = subprocess.Popen(
                 cmd,
                 cwd=cwd,
-                stdout=log_f,
-                stderr=subprocess.STDOUT
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1 # Line buffered
             )
         except FileNotFoundError:
              # If executable not found
              sys.stdout.write(f"\rError: Executable '{cmd[0]}' not found.\n")
              raise
+
+        # Thread function to read from stdout and write to log
+        def log_reader(proc, file_handle):
+            try:
+                for line in proc.stdout:
+                    timestamp = datetime.datetime.now().strftime("[%Y-%m-%d %H:%M:%S] ")
+                    file_handle.write(f"{timestamp}{line}")
+                    file_handle.flush()
+            except Exception as e:
+                file_handle.write(f"\nError reading output: {e}\n")
+
+        reader_thread = threading.Thread(target=log_reader, args=(process, log_f))
+        reader_thread.start()
 
         spinner = ["|", "/", "-", "\\"]
         idx = 0
@@ -56,6 +78,9 @@ def run_command_with_spinner(cmd, log_file_path, cwd=None, description="Processi
                 sys.stdout.flush()
                 idx = (idx + 1) % len(spinner)
                 time.sleep(0.1)
+
+            # Wait for reader to finish processing remaining output
+            reader_thread.join()
 
             # Clear spinner line
             sys.stdout.write(f"\r{' ' * (len(description) + 20)}\r")
@@ -68,5 +93,6 @@ def run_command_with_spinner(cmd, log_file_path, cwd=None, description="Processi
 
         except KeyboardInterrupt:
             process.kill()
+            reader_thread.join()
             sys.stdout.write("\nProcess interrupted by user.\n")
             raise


### PR DESCRIPTION
The optimizer logs were previously missing timestamps, making it difficult to diagnose hangs or slow steps (e.g., during geometry generation). 

Changes:
- Updated `optimizer/utils.py`: `run_command_with_spinner` now uses `subprocess.PIPE` and a dedicated `threading.Thread` to read stdout line-by-line.
- Added logic to prepend `[YYYY-MM-DD HH:MM:SS] ` to each log line.
- Ensured thread safety and proper cleanup (joining threads, closing files).

Verified by running a dummy script that prints with delays and checking the generated log file for correct timestamps.

---
*PR created automatically by Jules for task [691783028261578303](https://jules.google.com/task/691783028261578303) started by @LokiMetaSmith*