### PR TITLE
Refine: suppress benign localization stderr in export.js

### DIFF
--- a/export.js
+++ b/export.js
@@ -197,7 +197,11 @@ async function main() {
         const wrapper = await createOpenSCAD({
             noInitialRun: true,
             print: (text) => console.log("SCAD stdout:", text),
-            printErr: (text) => console.error("SCAD stderr:", text),
+            printErr: (text) => {
+                if (!text.includes("Could not initialize localization")) {
+                    console.error("SCAD stderr:", text);
+                }
+            },
             quit: (status, toThrow) => {
                 throw new Error("OpenSCAD Quit with status " + status);
             },


### PR DESCRIPTION
The `openscad-wasm` package emits a "Could not initialize localization" error on stderr during initialization. This is a known issue with the WASM build environment and is non-fatal. However, it clutters the logs and confuses users who interpret it as a build failure. This patch filters out this specific message from the stderr stream in `export.js`. (Includes previous fix for auto-quoting string parameters).