### PR TITLE
Fix geometry generation timeouts for CFD volumes

### DIFF
--- a/optimizer/scad_driver.py
+++ b/optimizer/scad_driver.py
@@ -62,6 +62,17 @@ class ScadDriver:
         if "GENERATE_SLICE" not in run_params:
              run_params["GENERATE_SLICE"] = "false"
 
+        # Check if CFD generation is requested (handle bool or string)
+        gen_cfd = run_params.get("GENERATE_CFD_VOLUME", "true")
+        if str(gen_cfd).lower() == "true":
+             if "CUT_FOR_VISIBILITY" not in run_params:
+                 # Disable visibility cut for CFD volume to save processing time
+                 run_params["CUT_FOR_VISIBILITY"] = "false"
+
+        # Limit resolution to prevent OOM/Timeouts if not specified
+        if "high_res_fn" not in run_params:
+             run_params["high_res_fn"] = 100
+
         param_args = []
         for key, value in run_params.items():
             param_args.extend(self._format_param(key, value))


### PR DESCRIPTION
Optimizes the OpenSCAD parameters passed by `ScadDriver` when generating CFD fluid volumes.

The issue was caused by excessive complexity in the OpenSCAD model when `GENERATE_CFD_VOLUME` was enabled. Specifically:
1. `CUT_FOR_VISIBILITY=true` (default in SCAD) adds a large difference operation that is unnecessary for the fluid volume and doubles the boolean workload.
2. The default `$fn` (200) is too high for complex helical sweeps in the WASM environment, leading to timeouts/OOM.

The fix automatically disables the visibility cut and reduces the resolution to a safe but sufficient level (100) for CFD meshing, unless explicitly overridden by the user parameters.

---
*PR created automatically by Jules for task [1548463958142691081](https://jules.google.com/task/1548463958142691081) started by @LokiMetaSmith*