### PR TITLE
Fix optimizer infinite loop and LLM model 404 error

### DIFF
--- a/corkscrewFilter/system/createPatchDict
+++ b/corkscrewFilter/system/createPatchDict
@@ -7,36 +7,36 @@
 |    \/     M anipulation  |                                                 |
 \*---------------------------------------------------------------------------*/
 FoamFile
-{{
+{
     version     2.0;
     format      ascii;
     class       dictionary;
     object      createPatchDict;
-}}
+}
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
 pointSync false;
 
 patches
 (
-    {{
+    {
         name inlet;
         patchInfo
-        {{
+        {
             type patch;
-        }}
+        }
         constructFrom set;
         set inlet_faces;
-    }}
-    {{
+    }
+    {
         name outlet;
         patchInfo
-        {{
+        {
             type patch;
-        }}
+        }
         constructFrom set;
         set outlet_faces;
-    }}
+    }
 );
 
 // ************************************************************************* //

--- a/optimizer/llm_agent.py
+++ b/optimizer/llm_agent.py
@@ -11,7 +11,7 @@ except ImportError:
     Image = None
 
 class LLMAgent:
-    def __init__(self, api_key=None, model_name="gemini-1.5-flash"):
+    def __init__(self, api_key=None, model_name="gemini-1.5-flash-001"):
         if not api_key:
             api_key = os.environ.get("GEMINI_API_KEY")
 

--- a/optimizer/main.py
+++ b/optimizer/main.py
@@ -73,9 +73,15 @@ def main():
         print(f"Result metrics: {metrics}")
 
         # Check for critical failure
-        if "error" in metrics and metrics["error"] == "geometry_generation_failed":
-             print("Skipping this iteration due to geometry failure.")
-             continue
+        if "error" in metrics:
+            if metrics["error"] == "environment_missing_tools":
+                print("\nCRITICAL ERROR: OpenFOAM tools not found.")
+                print("Please install OpenFOAM (simpleFoam, blockMesh) or Docker, or run with --dry-run.")
+                print("Aborting optimization.")
+                break
+            elif metrics["error"] == "geometry_generation_failed":
+                print("Skipping this iteration due to geometry failure.")
+                continue
 
         # 5. Save Results
         run_data = {

--- a/optimizer/simulation_runner.py
+++ b/optimizer/simulation_runner.py
@@ -53,6 +53,11 @@ def run_simulation(scad_driver, foam_driver, params, output_stl_name="corkscrew_
 
     # 2. Update Mesh Config
     if not dry_run:
+        # Early check for environment
+        if not foam_driver.has_tools:
+            print("OpenFOAM tools not found. Skipping simulation.")
+            return {"error": "environment_missing_tools", "details": "Neither OpenFOAM nor Docker found"}, []
+
         bounds = scad_driver.get_bounds(stl_path)
         if bounds[0] is None:
             print("Failed to get bounds. Using default.")


### PR DESCRIPTION
This PR addresses two critical issues preventing the optimization loop from functioning correctly:
1.  **Infinite Failure Loop:** Previously, if OpenFOAM executables were missing, the script would crash or fail silently, allowing the loop to continue without results. Now, the system detects missing tools early and aborts the optimization process with a clear error message.
2.  **LLM 404 Error:** The `google-genai` library was failing to find `gemini-1.5-flash` due to API versioning. The model name has been pinned to `gemini-1.5-flash-001`.

Verified via dry-run and simulated environment failure tests.

---
*PR created automatically by Jules for task [18206825289012617613](https://jules.google.com/task/18206825289012617613) started by @LokiMetaSmith*