### PR TITLE
Fix OpenSCAD high_res_fn recursion crash in config.scad

### DIFF
--- a/config.scad
+++ b/config.scad
@@ -39,13 +39,13 @@ CUT_FOR_VISIBILITY = true;      // If true, cuts the model in half (removes Y>0)
 // =============================================================================
 
 // --- General & Precision ---
-high_res_fn = is_undef(high_res_fn) ? 200 : high_res_fn; // Fragment resolution for final renders ($fn). Higher values create smoother curves.
-if (high_res_fn > 60) {
+_requested_high_res_fn = is_undef(high_res_fn) ? 200 : high_res_fn; // Fragment resolution for final renders ($fn). Higher values create smoother curves.
+if (_requested_high_res_fn > 60) {
     echo("WARNING: high_res_fn capped at 60 for performance stability in WASM environment.");
 }
-high_res_fn = min(high_res_fn, 60); // Cap resolution to prevent timeouts in WASM environment
+_actual_high_res_fn = min(_requested_high_res_fn, 60); // Cap resolution to prevent timeouts in WASM environment
 low_res_fn = is_undef(low_res_fn) ? 10 : low_res_fn;   // Fragment resolution for previews. Lower values provide faster previews.
-$fn = $preview ? low_res_fn : high_res_fn; // OpenSCAD automatically uses the appropriate value.
+$fn = $preview ? low_res_fn : _actual_high_res_fn; // OpenSCAD automatically uses the appropriate value.
 
 // --- Tube & Main Assembly Parameters ---
 tube_od_mm = 32;                 // The outer diameter of the tube the filter assembly will be inserted into.


### PR DESCRIPTION
Fixes a critical bug where the optimization loop failed during geometry generation due to an OpenSCAD error.
The `high_res_fn` logic was attempting to modify itself in a way that is invalid in OpenSCAD (variables are set at compile-time/scope-time, and self-reference resolves to undef during definition).
This caused `high_res_fn` to be `undef`, causing `min(high_res_fn, 60)` to fail and crash the process.

Changes:
- Modified `config.scad` to use `_requested_high_res_fn` and `_actual_high_res_fn` for logic.
- Ensures `$fn` is set correctly.
- Verified by running `export.js` with parameters that previously failed.

---
*PR created automatically by Jules for task [5922325320092703072](https://jules.google.com/task/5922325320092703072) started by @LokiMetaSmith*