### PR TITLE
Fix duplicate screw segment geometry in ModularFilterAssembly

### DIFF
--- a/modules/assemblies.scad
+++ b/modules/assemblies.scad
@@ -42,11 +42,6 @@ module ModularFilterAssembly(tube_id, total_length) {
             z_pos = -total_length / 2 + spacer_height_mm + i * (bin_length + spacer_height_mm) + bin_length / 2;
             rot = twist_rate * z_pos;
 
-            #translate([0, 0, z_pos]) rotate([0, 0, rot]) {
-                intersection() {
-                    rotate([0, 0, -rot]) translate([0, 0, -z_pos]) MasterHollowHelix();
-                    cylinder(h = bin_length + 0.1, d = tube_id * 2, center = true);
-                }
             // Generate hollow segment directly with slight overlap for continuity
             local_h = bin_length + 0.02;
             local_twist = twist_rate * local_h;


### PR DESCRIPTION
Fixed a geometry bug in `ModularFilterAssembly` where a legacy code block (intended to be replaced) was left active and incorrectly nested, causing duplicate geometry generation.
- Removed redundant `#translate` and `intersection` block in `modules/assemblies.scad`.
- Verified syntax to ensure balanced braces.
- Regression tests pass (modulo expected timeouts due to environment limitations).

---
*PR created automatically by Jules for task [8861470861736985958](https://jules.google.com/task/8861470861736985958) started by @LokiMetaSmith*