### PR TITLE
fix(foam_driver): ensure OpenFOAM environment is loaded in container

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -76,7 +76,7 @@ class FoamDriver:
             "-w", container_workdir,
         ] + uid_gid_args + [
             self.docker_image,
-            "/bin/bash", "-c", " ".join(cmd)
+            "/bin/bash", "-lc", " ".join(cmd)
         ]
 
         return container_cmd


### PR DESCRIPTION
Updated `optimizer/foam_driver.py` to use `/bin/bash -lc` instead of `/bin/bash -c` when constructing container commands. This ensures that the OpenFOAM environment is sourced inside the container, preventing "command not found" errors during meshing and simulation.

---
*PR created automatically by Jules for task [12238167780505107431](https://jules.google.com/task/12238167780505107431) started by @LokiMetaSmith*