### PR TITLE
Fix OpenFOAM container working directory issue

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -94,7 +94,7 @@ class FoamDriver:
             "-w", container_workdir,
         ] + uid_gid_args + [
             self.docker_image,
-            "/bin/bash", "-lc", " ".join(cmd)
+            "/bin/bash", "-lc", f"cd {container_workdir} && " + " ".join(cmd)
         ]
 
         return container_cmd


### PR DESCRIPTION
Fixed an issue where OpenFOAM commands executed in containers (Podman/Docker) were failing with "file not found" errors because the login shell (`bash -l`) reset the working directory to `/root`.

Changes:
- Modified `optimizer/foam_driver.py`: Prepend `cd /home/openfoam/run &&` to the command string passed to `bash -lc`.

---
*PR created automatically by Jules for task [17689896875554381483](https://jules.google.com/task/17689896875554381483) started by @LokiMetaSmith*