### PR TITLE
fix: LLM model name 404 and feat: add --reuse-mesh capability

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -112,11 +112,11 @@ class FoamDriver:
 
         return container_cmd
 
-    def prepare_case(self):
+    def prepare_case(self, keep_mesh=False):
         """
         Prepares the case directory.
         """
-        if self.case_dir != self.template_dir:
+        if not keep_mesh and self.case_dir != self.template_dir:
             if os.path.exists(self.case_dir):
                 shutil.rmtree(self.case_dir)
             shutil.copytree(self.template_dir, self.case_dir)

--- a/optimizer/llm_agent.py
+++ b/optimizer/llm_agent.py
@@ -11,7 +11,7 @@ except ImportError:
     Image = None
 
 class LLMAgent:
-    def __init__(self, api_key=None, model_name="gemini-1.5-flash-001"):
+    def __init__(self, api_key=None, model_name="gemini-1.5-flash"):
         if not api_key:
             api_key = os.environ.get("GEMINI_API_KEY")
 

--- a/optimizer/main.py
+++ b/optimizer/main.py
@@ -18,6 +18,7 @@ def main():
     parser.add_argument("--output-stl", type=str, default="corkscrew_fluid.stl", help="Output STL filename")
     parser.add_argument("--dry-run", action="store_true", help="Skip actual OpenFOAM execution (mocks everything)")
     parser.add_argument("--skip-cfd", action="store_true", help="Generate geometry but skip CFD simulation")
+    parser.add_argument("--reuse-mesh", action="store_true", help="Reuse existing mesh (skips geometry generation and meshing)")
     args = parser.parse_args()
 
     # Initialize components
@@ -69,7 +70,8 @@ def main():
             output_stl_name=args.output_stl,
             dry_run=args.dry_run,
             skip_cfd=args.skip_cfd,
-            iteration=i
+            iteration=i,
+            reuse_mesh=args.reuse_mesh
         )
 
         print(f"Result metrics: {metrics}")


### PR DESCRIPTION
This PR addresses two issues:
1.  **LLM API Error:** The default model name `gemini-1.5-flash-001` was causing a 404 error. It has been updated to the stable alias `gemini-1.5-flash`.
2.  **Mesh Reuse:** A new feature has been added to allow users to rerun the solver on an existing mesh without regenerating geometry or re-meshing. This is useful for debugging or re-running simulations with different solver settings on the same geometry.
    -   Added `--reuse-mesh` flag to `main.py`.
    -   Modified `run_simulation` to conditionally skip `scad_driver.generate_stl`, `update_blockMesh`, and `run_meshing`.
    -   Modified `FoamDriver.prepare_case` to accept a `keep_mesh` argument, which prevents wiping the case directory.


---
*PR created automatically by Jules for task [4379776125568093292](https://jules.google.com/task/4379776125568093292) started by @LokiMetaSmith*