### PR TITLE
Fix Filter Holder missing geometry and add new parameters

### DIFF
--- a/config.scad
+++ b/config.scad
@@ -91,6 +91,8 @@ filter_holder_cartridge_thread_inner = false;
 filter_holder_cartridge_thread_outer = false;
 filter_holder_tube_thread_inner = false;
 filter_holder_tube_thread_outer = true;
+filter_holder_cartridge_wall_height = 10;
+filter_holder_cartridge_offset = 0;
 
 // --- Custom Coupling Parameters ---
 // These are defaults, usually overridden by including a specific config file.

--- a/modules/filter_holder.scad
+++ b/modules/filter_holder.scad
@@ -19,6 +19,8 @@ include <primitives.scad>
  * tube_thread_outer: (bool) If true, adds external threads (Plug) for the tube (fits inside tube).
  * tube_wall: Wall thickness of the pipe (needed for flange calculation if threaded).
  * use_colors: (bool) If true, applies distinct colors to sub-parts for visualization.
+ * cartridge_wall_height: (float) Height of the cartridge holder rim/screw.
+ * cartridge_offset: (float) Height offset from the base for the cartridge holder.
  */
 module FilterHolder(
     tube_id = 30, // Fits inside this pipe (ID)
@@ -31,12 +33,13 @@ module FilterHolder(
     tube_thread_outer = true,
     oring_cs = 1.5,
     tube_wall = 2,
-    use_colors = true
+    use_colors = true,
+    cartridge_wall_height = 10,
+    cartridge_offset = 0
 ) {
     // Dimensions
     base_height = 5;
     lip_height = 10;
-    segment_h = lip_height / 2;
 
     // Derived Dimensions
 
@@ -55,15 +58,15 @@ module FilterHolder(
     socket_id = cartridge_od + 0.2;
 
     // Nipple (Male, Outer Thread) OD
-    // Assumption: Mating part has ID = cartridge_od.
     nipple_od = cartridge_od - 0.2;
 
-    // Base Plate Calculation
-    // Must be large enough to support the largest outer feature.
-    // If Cap enabled, must cover Cap OD.
-    // If Plug enabled (threaded), usually has a flange.
-    // If neither, usually fits inside tube (no flange, or small lip).
+    // Calculate Cartridge Feature OD (The core cylinder we need to keep/generate)
+    cartridge_feature_od = max(
+        cartridge_thread_outer ? nipple_od : 0,
+        cartridge_thread_inner ? (socket_id + 4) : (cartridge_od + 4)
+    );
 
+    // Base Plate Calculation
     base_plate_min_d = max(
         tube_thread_inner ? cap_od : 0,
         tube_thread_outer ? (tube_id + 2*max(tube_wall, 2)) : (tube_id - 0.2)
@@ -93,43 +96,41 @@ module FilterHolder(
 
         // 2. Main Body Plate
         difference() {
-            if (use_colors) color("Chartreuse", 1.0) cylinder(d = base_plate_od, h = base_height, $fn=$fn);
-            else cylinder(d = base_plate_od, h = base_height, $fn=$fn);
+            if (use_colors) color("Chartreuse", 1.0) cylinder(d = base_plate_od, h = base_height, anchor=BOTTOM, $fn=$fn);
+            else cylinder(d = base_plate_od, h = base_height, anchor=BOTTOM, $fn=$fn);
 
             // Center hole for flow
-            translate([0,0,-1]) cylinder(d = barb_id, h = base_height + 2, $fn=$fn);
+            translate([0,0,-1]) cylinder(d = barb_id, h = base_height + 2, anchor=BOTTOM, $fn=$fn);
 
             // Face Seals (Underside of Base Plate)
 
             // Tube Interface Seals
             if (tube_thread_outer) {
                 // Plug Flange Seal (against Tube Rim)
-                // Groove at mean diameter of tube wall
-                rim_center = tube_id + tube_wall;
-                // Alternatively, closer to ID or OD. Original was base_plate_od - oring_cs.
-                // If base_plate_od is huge (due to Cap), this is wrong.
-                // It should seal against the tube end face.
                 rim_seal_d = tube_id + tube_wall;
                 OringGroove_Face_Cutter(rim_seal_d, oring_cs);
             }
             if (tube_thread_inner) {
-                // Cap Face Seal (against Tube Rim)
-                // Also seals against the tube rim.
-                // If both are true, we only need one seal.
+                // Cap Face Seal
                 if (!tube_thread_outer) {
                     rim_seal_d = tube_id + tube_wall;
                     OringGroove_Face_Cutter(rim_seal_d, oring_cs);
                 }
             }
 
-            // Cartridge Interface Seals (Ceiling of Socket)
+            // Cartridge Interface Seals
             if (cartridge_thread_inner) {
-                // Face seal at the bottom of the socket (top of the cartridge)
-                OringGroove_Face_Cutter(socket_id + 2, oring_cs); // Slightly larger than hole
+                // Face seal at the bottom of the socket
+                OringGroove_Face_Cutter(socket_id + 2, oring_cs);
             }
         }
 
         // 3. Interface Lips (Extending Downwards)
+        // Translate to the bottom of the base plate (Z=0) and point downwards?
+        // Original code: translate([0, 0, -lip_height])
+        // And generated geometry upwards from there.
+        // We will keep that coordinate system for consistency.
+
         translate([0, 0, -lip_height]) {
             difference() {
                 union() {
@@ -138,118 +139,103 @@ module FilterHolder(
                     // A. Plug (Fits inside Tube)
                     if (tube_thread_outer) {
                         // Threaded Plug
-                        translate([0,0,segment_h])
-                            if (use_colors) color("Orange", 1.0) threaded_rod(d=tube_id, h=lip_height, pitch=1.5, internal=false, $fn=$fn);
-                            else threaded_rod(d=tube_id, h=lip_height, pitch=1.5, internal=false, $fn=$fn);
+                        // Generated from Z=0 upwards to lip_height
+                        if (use_colors) color("Orange", 1.0)
+                            threaded_rod(d=tube_id, h=lip_height, pitch=1.5, internal=false, anchor=BOTTOM, $fn=$fn);
+                        else
+                            threaded_rod(d=tube_id, h=lip_height, pitch=1.5, internal=false, anchor=BOTTOM, $fn=$fn);
                     } else if (!tube_thread_inner) {
-                        // Smooth Plug (Only if no Cap, or can coexist?)
-                        // If we want "Plug AND Cap", we generate both.
-                        // Standard "Smooth Plug" behavior if no threads requested on tube.
-                         translate([0,0,segment_h]) {
-                             if (use_colors) color("Orange", 1.0) cylinder(d=plug_od, h=segment_h, $fn=$fn);
-                             else cylinder(d=plug_od, h=segment_h, $fn=$fn);
+                        // Smooth Plug
+                         if (use_colors) color("Orange", 1.0) cylinder(d=plug_od, h=lip_height/2, anchor=BOTTOM, $fn=$fn);
+                         else cylinder(d=plug_od, h=lip_height/2, anchor=BOTTOM, $fn=$fn);
+
+                         translate([0,0,lip_height/2]) {
+                             if (use_colors) color("Gold", 1.0) cylinder(d=plug_od, h=lip_height/2, anchor=BOTTOM, $fn=$fn);
+                             else cylinder(d=plug_od, h=lip_height/2, anchor=BOTTOM, $fn=$fn);
                          }
-                         if (use_colors) color("Gold", 1.0) cylinder(d=plug_od, h=segment_h, $fn=$fn);
-                         else cylinder(d=plug_od, h=segment_h, $fn=$fn);
                     }
 
                     // B. Cap (Fits over Tube)
                     if (tube_thread_inner) {
                         // Outer Wall for Cap
-                         translate([0,0,segment_h]) {
-                            if (use_colors) color("Red", 1.0) cylinder(d=cap_od, h=lip_height, $fn=$fn);
-                            else cylinder(d=cap_od, h=lip_height, $fn=$fn);
-                         }
+                        if (use_colors) color("Red", 1.0) cylinder(d=cap_od, h=lip_height, anchor=BOTTOM, $fn=$fn);
+                        else cylinder(d=cap_od, h=lip_height, anchor=BOTTOM, $fn=$fn);
                     }
 
                     // --- CARTRIDGE INTERFACE GEOMETRY ---
+                    // Explicitly generate the cartridge holder.
 
-                    // C. Nipple (Fits into Cartridge? No, Cartridge screws ONTO Nipple)
-                    // Nipple is a male stud.
-                    if (cartridge_thread_outer) {
-                         translate([0,0,segment_h])
-                            if (use_colors) color("Cyan", 1.0) threaded_rod(d=nipple_od, h=lip_height, pitch=1.5, internal=false, $fn=$fn);
-                            else threaded_rod(d=nipple_od, h=lip_height, pitch=1.5, internal=false, $fn=$fn);
+                    translate([0,0,cartridge_offset]) {
+                        if (cartridge_thread_outer) {
+                             // Nipple (Threaded Stud)
+                             if (use_colors) color("Cyan", 1.0)
+                                threaded_rod(d=nipple_od, h=cartridge_wall_height, pitch=1.5, internal=false, anchor=BOTTOM, $fn=$fn);
+                             else
+                                threaded_rod(d=nipple_od, h=cartridge_wall_height, pitch=1.5, internal=false, anchor=BOTTOM, $fn=$fn);
+                        } else {
+                            // Socket Wall / Core (Smooth Cylinder)
+                            if (use_colors) color("Purple", 1.0)
+                                cylinder(d=cartridge_feature_od, h=cartridge_wall_height, anchor=BOTTOM, $fn=$fn);
+                            else
+                                cylinder(d=cartridge_feature_od, h=cartridge_wall_height, anchor=BOTTOM, $fn=$fn);
+                        }
                     }
 
-                    // D. Socket (Cartridge fits INTO Holder)
-                    // We need material to cut the socket into.
-                    // Or "Smooth Socket" material.
-                    // This material is usually the inner core of the plug.
-                    // If Nipple exists, it provides material.
-                    // If Plug exists, it provides material.
-                    // If neither, we need a core cylinder.
-
-                    core_needed_od = max(
-                        cartridge_thread_outer ? 0 : 0,
-                        cartridge_thread_inner ? (socket_id + 4) : (cartridge_od + 4)
-                    );
-
-                    // If plug is solid, it covers this.
-                    // But if plug is hollow or non-existent, we need explicit core.
-
-                    if (!tube_thread_outer && !cartridge_thread_outer) {
-                        // Provide core material for socket
-                        if (use_colors) color("Purple", 1.0) cylinder(d=core_needed_od, h=lip_height, $fn=$fn);
-                        else cylinder(d=core_needed_od, h=lip_height, $fn=$fn);
-                    }
-
-                    // Connect everything to base
+                    // Connect everything to base (Ensure solid connection at top)
                     translate([0,0,lip_height-1])
-                        cylinder(d=base_plate_od, h=1, $fn=$fn);
+                        cylinder(d=base_plate_od, h=1, anchor=BOTTOM, $fn=$fn);
                 }
 
                 // --- SUBTRACTIONS ---
 
                 // 1. Cap Internal Threads
                 if (tube_thread_inner) {
-                     translate([0,0,segment_h-1])
-                        threaded_rod(d=cap_id, h=lip_height+2, pitch=1.5, internal=true, $fn=$fn);
+                     translate([0,0,-1])
+                        threaded_rod(d=cap_id, h=lip_height+2, pitch=1.5, internal=true, anchor=BOTTOM, $fn=$fn);
                 }
 
                 // 2. Socket Internal Threads
                 if (cartridge_thread_inner) {
-                     translate([0,0,segment_h-1])
-                        threaded_rod(d=socket_id, h=lip_height+2, pitch=1.5, internal=true, $fn=$fn);
-                } else {
-                    // Smooth Socket (if not threaded and not Nipple)
-                    // If it's a Nipple, we don't bore a socket unless requested.
-                    // But we always need flow path.
+                     translate([0,0,cartridge_offset-1])
+                        threaded_rod(d=socket_id, h=cartridge_wall_height+2, pitch=1.5, internal=true, anchor=BOTTOM, $fn=$fn);
                 }
 
                 // 3. Clear Center Flow Path
-                // Must be smaller than barb_id usually, or same.
-                translate([0,0,-1]) cylinder(d = barb_id, h = lip_height + 50, $fn=$fn);
+                translate([0,0,-1]) cylinder(d = barb_id, h = lip_height + 50, anchor=BOTTOM, $fn=$fn);
 
                 // 4. O-Ring Grooves (Radial)
+                // Positioned relative to lip_height/2 (center of lip section) if strictly centered,
+                // but for now we assume they are at Z = 0.75 * lip_height relative to our group?
+                // Original: translate([0,0,segment_h + segment_h/2]) -> Z=7.5.
+                // Our group base is -10. 7.5 relative to base? No.
+                // Original Plug was translated to segment_h (5). segment_h/2 = 2.5.
+                // So original radial seal was at 5+2.5 = 7.5.
+                // Global Z: -10 + 7.5 = -2.5.
 
-                // Tube Interface (Radial)
                 if (!tube_thread_outer && !tube_thread_inner) {
                     // Smooth Plug Radial Seal
-                    translate([0,0,segment_h + segment_h/2])
+                    translate([0,0, lip_height * 0.75])
                         OringGroove_OD_Cutter(plug_od, oring_cs);
                 }
 
-                // Cartridge Interface (Radial)
                 if (!cartridge_thread_inner && !cartridge_thread_outer) {
-                    // Smooth Socket Radial Seal (ID Groove)
-                    translate([0,0,segment_h + segment_h/2])
+                    // Smooth Socket Radial Seal
+                    // Should be relative to cartridge holder.
+                    // If cartridge_wall_height is small, this might be off.
+                    // Assuming default 10mm height, 7.5mm is fine.
+                    translate([0,0, cartridge_offset + (cartridge_wall_height * 0.75)])
                         OringGroove_ID_Cutter(socket_id, oring_cs);
                 }
 
                 // 5. Cleanup / Hollows
-                // If Plug is threaded, hollow it out to reduce material,
-                // but leave enough for Cartridge interface.
+                // If Plug exists, we want to hollow it out to create the annular space for the tube wall.
                 if (tube_thread_outer) {
-                    // ID of the outer plug wall
                     plug_wall_id = tube_id - 4;
-                    // OD of the inner cartridge interface (Socket wall or Nipple)
-                    cartridge_feature_od = cartridge_thread_outer ? nipple_od : (socket_id + 4);
-
+                    // Check if we need to clean up
                     if (plug_wall_id > cartridge_feature_od) {
                         translate([0,0,-1]) difference() {
-                            cylinder(d=plug_wall_id, h=lip_height+2, $fn=$fn);
-                            cylinder(d=cartridge_feature_od, h=lip_height+3, $fn=$fn);
+                            cylinder(d=plug_wall_id, h=lip_height+2, anchor=BOTTOM, $fn=$fn);
+                            cylinder(d=cartridge_feature_od, h=lip_height+3, anchor=BOTTOM, $fn=$fn);
                         }
                     }
                 }
@@ -265,18 +251,23 @@ module FilterHolder(
                           OringVisualizer_Face(rim_seal_d, oring_cs);
                  } else {
                      // Radial Seal
-                     translate([0,0,segment_h + segment_h/2])
+                     translate([0,0, lip_height * 0.75])
                         OringVisualizer(plug_od, oring_cs);
                  }
 
                  // Cartridge Interface
                  if (cartridge_thread_inner) {
-                     // Face Seal
+                     // Face Seal (Top of cartridge/Bottom of socket)
+                     // If socket thread inner, the seal is usually at the bottom of the hole?
+                     // Or at the face?
+                     // Code said: translate([0, 0, lip_height]).
+                     // But socket is inside.
+                     // Usually cartridge presses against base plate.
                      translate([0, 0, lip_height])
                         OringVisualizer_Face(socket_id+2, oring_cs);
                  } else if (!cartridge_thread_outer) {
                      // Radial Seal
-                     translate([0,0,segment_h + segment_h/2])
+                     translate([0,0, cartridge_offset + (cartridge_wall_height * 0.75)])
                         OringVisualizer_ID(socket_id, oring_cs);
                  }
             }


### PR DESCRIPTION
This change addresses an issue where the cartridge holder geometry (inner core) was missing when `tube_thread_outer` was enabled, leading to a "floating o-ring". It introduces explicit generation for the cartridge holder, decouples it from the plug geometry, and adds new parameters (`cartridge_wall_height`, `cartridge_offset`) to control its dimensions. It also improves geometry robustness by using explicit anchoring.

---
*PR created automatically by Jules for task [12256032489971876990](https://jules.google.com/task/12256032489971876990) started by @LokiMetaSmith*