### PR TITLE
Fix OpenFOAM v2406 configuration errors in corkscrewFilter

### DIFF
--- a/corkscrewFilter/system/blockMeshDict
+++ b/corkscrewFilter/system/blockMeshDict
@@ -19,7 +19,7 @@ FoamFile
 // that is slightly LARGER than your STL file in all directions.
 // The current values are placeholders.
 
-convertToMeters 1;
+scale 1;
 
 vertices
 (

--- a/corkscrewFilter/system/snappyHexMeshDict
+++ b/corkscrewFilter/system/snappyHexMeshDict
@@ -19,6 +19,8 @@ castellatedMesh true;
 snap            true;
 addLayers       true;
 
+mergeTolerance  1e-6;
+
 geometry
 {
     corkscrew_fluid.stl

--- a/corkscrewFilter/system/surfaceFeatureExtractDict
+++ b/corkscrewFilter/system/surfaceFeatureExtractDict
@@ -15,15 +15,16 @@ FoamFile
 }
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-surface         "corkscrew_fluid.stl";
-
-extractionMethod    extractFromSurface;
-
-extractFromSurfaceCoeffs
+corkscrew_fluid.stl
 {
-    includedAngle   150;
-}
+    extractionMethod    extractFromSurface;
 
-writeObj        true;
+    extractFromSurfaceCoeffs
+    {
+        includedAngle   150;
+    }
+
+    writeObj        true;
+}
 
 // ************************************************************************* //


### PR DESCRIPTION
This PR fixes configuration issues preventing the OpenFOAM case from running on v2406. Specifically, it addresses a missing `mergeTolerance` entry in `snappyHexMeshDict` which caused a crash, updates a deprecated keyword in `blockMeshDict`, and corrects the syntax in `surfaceFeatureExtractDict` which was causing silent failures in feature extraction.

---
*PR created automatically by Jules for task [405710868192540594](https://jules.google.com/task/405710868192540594) started by @LokiMetaSmith*