### PR TITLE
Fix OpenFOAM snappyHexMeshDict missing refinementRegions

### DIFF
--- a/corkscrewFilter/system/snappyHexMeshDict
+++ b/corkscrewFilter/system/snappyHexMeshDict
@@ -53,6 +53,9 @@ castellatedMeshControls
         }
     }
 
+    refinementRegions
+    {}
+
     resolveFeatureAngle 30;
 
     locationInMesh (10 0 0); // A point inside the fluid volume (annulus)


### PR DESCRIPTION
- Add empty `refinementRegions` dictionary to `corkscrewFilter/system/snappyHexMeshDict` to satisfy OpenFOAM v2406 requirements.