### PR TITLE
fix(foam): add missing errorReduction to snappyHexMeshDict

### DIFF
--- a/corkscrewFilter/system/snappyHexMeshDict
+++ b/corkscrewFilter/system/snappyHexMeshDict
@@ -101,6 +101,7 @@ meshQualityControls
     minFaceWeight 0.05;
     minVolRatio 0.01;
     minTriangleTwist -1;
+    errorReduction 0.75;
 }
 
 // ************************************************************************* //


### PR DESCRIPTION
Added `errorReduction 0.75;` to `corkscrewFilter/system/snappyHexMeshDict` to fix a crash in OpenFOAM v2406 during meshing. This parameter is required by the `meshQualityControls` dictionary in this version.

---
*PR created automatically by Jules for task [11795597076978025414](https://jules.google.com/task/11795597076978025414) started by @LokiMetaSmith*