### PR TITLE
Fix missing errorReduction in snappyHexMeshDict

### DIFF
--- a/corkscrewFilter/system/snappyHexMeshDict
+++ b/corkscrewFilter/system/snappyHexMeshDict
@@ -88,6 +88,7 @@ snapControls
 
 meshQualityControls
 {
+    errorReduction 0.75;
     maxNonOrtho 65;
     maxBoundarySkewness 20;
     maxInternalSkewness 4;


### PR DESCRIPTION
- Added `errorReduction 0.75;` to `system/snappyHexMeshDict` to fix OpenFOAM v2406 crash in `meshQualityControls`.
- This is a follow-up fix to the previous `allowFreeStandingZoneFaces` addition, addressing a subsequent IO error revealed during execution.