### PR TITLE
Update .gitignore for OpenFOAM artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ logs/
 corkscrewFilter/constant/extendedFeatureEdgeMesh/
 corkscrewFilter/constant/polyMesh/
 corkscrewFilter/constant/triSurface/*.eMesh
-optimization_log.jsonl

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ logs/
 .venv/*
 *.bak
 *.stl
+corkscrewFilter/constant/extendedFeatureEdgeMesh/
+corkscrewFilter/constant/polyMesh/
+corkscrewFilter/constant/triSurface/*.eMesh
+optimization_log.jsonl


### PR DESCRIPTION
Updated `.gitignore` to include OpenFOAM mesh and feature edge mesh directories, as well as the optimization log file, as requested. These files are generated during the simulation and optimization process and should not be tracked by version control.

---
*PR created automatically by Jules for task [14964740233353000834](https://jules.google.com/task/14964740233353000834) started by @LokiMetaSmith*