### PR TITLE
Fix OpenFOAM v2406 snappyHexMesh configuration error

### DIFF
--- a/corkscrewFilter/system/snappyHexMeshDict
+++ b/corkscrewFilter/system/snappyHexMeshDict
@@ -88,6 +88,7 @@ snapControls
 
 meshQualityControls
 {
+    nSmoothScale 4;
     errorReduction 0.75;
     maxNonOrtho 65;
     maxBoundarySkewness 20;


### PR DESCRIPTION
The `snappyHexMesh` utility in OpenFOAM v2406 requires the `nSmoothScale` parameter in the `meshQualityControls` dictionary. This parameter was missing, causing a fatal IO error. Added `nSmoothScale 4;` to `corkscrewFilter/system/snappyHexMeshDict` to fix the issue. Verified the syntax by static inspection.

---
*PR created automatically by Jules for task [10742874790853964407](https://jules.google.com/task/10742874790853964407) started by @LokiMetaSmith*