### PR TITLE
Fix snappyHexMesh missing nSmoothScale error

### DIFF
--- a/corkscrewFilter/system/snappyHexMeshDict
+++ b/corkscrewFilter/system/snappyHexMeshDict
@@ -88,6 +88,7 @@ snapControls
 
 meshQualityControls
 {
+    nSmoothScale 4;
     errorReduction 0.75;
     maxNonOrtho 65;
     maxBoundarySkewness 20;


### PR DESCRIPTION
This PR fixes a fatal IO error in OpenFOAM v2406 where `snappyHexMesh` would crash with "Entry 'nSmoothScale' not found in dictionary".
I have added `nSmoothScale 4;` to the `meshQualityControls` section of `corkscrewFilter/system/snappyHexMeshDict`.
This parameter is a standard setting for mesh quality controls.

---
*PR created automatically by Jules for task [13684835140075337961](https://jules.google.com/task/13684835140075337961) started by @LokiMetaSmith*