### PR TITLE
Fix OpenFOAM v2406 snappyHexMesh featureAngle error

### DIFF
--- a/corkscrewFilter/system/snappyHexMeshDict
+++ b/corkscrewFilter/system/snappyHexMeshDict
@@ -76,6 +76,7 @@ addLayersControls
     finalLayerThickness 0.3;
     minThickness 0.1;
     nGrow 0;
+    featureAngle 130;
 }
 
 snapControls


### PR DESCRIPTION
Added `featureAngle 130;` to `addLayersControls` in `corkscrewFilter/system/snappyHexMeshDict` to resolve a fatal IO error in OpenFOAM v2406.

---
*PR created automatically by Jules for task [9079249579115837706](https://jules.google.com/task/9079249579115837706) started by @LokiMetaSmith*