### PR TITLE
Fix snappyHexMeshDict FATAL IO ERROR for OpenFOAM v2406

### DIFF
--- a/corkscrewFilter/system/snappyHexMeshDict
+++ b/corkscrewFilter/system/snappyHexMeshDict
@@ -77,6 +77,9 @@ addLayersControls
     minThickness 0.1;
     nGrow 0;
     featureAngle 130;
+    maxFaceThicknessRatio 0.5;
+    maxThicknessToMedialRatio 0.3;
+    minMedianAxisAngle 90;
 }
 
 snapControls


### PR DESCRIPTION
This change fixes a fatal IO error in `snappyHexMesh` when running with OpenFOAM v2406. 

The error `Entry 'maxFaceThicknessRatio' not found` indicated that the configuration file was missing parameters required by newer OpenFOAM versions for layer generation. 

I have added the missing `maxFaceThicknessRatio` parameter, along with `maxThicknessToMedialRatio` and `minMedianAxisAngle`, which are also standard requirements for `addLayersControls` in recent versions, to prevent further failures.

---
*PR created automatically by Jules for task [3828560194847282024](https://jules.google.com/task/3828560194847282024) started by @LokiMetaSmith*