### PR TITLE
Fix meshing failures: dynamic locationInMesh and numpy fix

### DIFF
--- a/optimizer/simulation_runner.py
+++ b/optimizer/simulation_runner.py
@@ -69,6 +69,7 @@ def run_simulation(scad_driver, foam_driver, params, output_stl_name="corkscrew_
                 print("Failed to get bounds. Using default.")
             else:
                 foam_driver.update_blockMesh(bounds)
+                foam_driver.update_snappyHexMesh_location(bounds)
         else:
             print("[Reuse Mesh] Skipping BlockMesh update.")
     elif skip_cfd:


### PR DESCRIPTION
This PR addresses recurring `meshing_failed` errors in the OpenFOAM optimization loop.

Changes:
- **`optimizer/foam_driver.py`**:
    - Fixed a `ValueError` in `update_blockMesh` caused by ambiguous boolean check of numpy arrays (`bounds`).
    - Added `update_snappyHexMesh_location` method to dynamically update the `locationInMesh` parameter in `snappyHexMeshDict` based on the geometry's bounding box. This ensures the seed point remains inside the fluid domain (annulus) even as `tube_od_mm` changes.
    - Updated `prepare_case` to explicitly recreate `constant/extendedFeatureEdgeMesh` to prevent stale data or missing directory issues for `surfaceFeatureExtract`.
- **`optimizer/simulation_runner.py`**:
    - Calls `update_snappyHexMesh_location` after generating geometry and updating `blockMesh`.

These changes improve the robustness of the meshing pipeline against geometric variations and fix a python runtime error.

---
*PR created automatically by Jules for task [12171681512657170682](https://jules.google.com/task/12171681512657170682) started by @LokiMetaSmith*