### PR TITLE
Fix snappyHexMesh nBufferCellsNoExtrude error for OpenFOAM v2406

### DIFF
--- a/corkscrewFilter/system/snappyHexMeshDict
+++ b/corkscrewFilter/system/snappyHexMeshDict
@@ -80,6 +80,7 @@ addLayersControls
     maxFaceThicknessRatio 0.5;
     maxThicknessToMedialRatio 0.3;
     minMedianAxisAngle 90;
+    nBufferCellsNoExtrude 0;
 }
 
 snapControls


### PR DESCRIPTION
This PR fixes a fatal IO error in `snappyHexMesh` when running with OpenFOAM v2406. The error "Entry 'nBufferCellsNoExtrude' not found" is resolved by adding the missing parameter to the configuration dictionary. This ensures compatibility with the specified OpenFOAM version used in the project's container environment.

---
*PR created automatically by Jules for task [9052165455697799589](https://jules.google.com/task/9052165455697799589) started by @LokiMetaSmith*