### PR TITLE
Fix snappyHexMesh IO error: missing nLayerIter

### DIFF
--- a/corkscrewFilter/system/snappyHexMeshDict
+++ b/corkscrewFilter/system/snappyHexMeshDict
@@ -81,6 +81,7 @@ addLayersControls
     maxThicknessToMedialRatio 0.3;
     minMedianAxisAngle 90;
     nBufferCellsNoExtrude 0;
+    nLayerIter 50;
 }
 
 snapControls


### PR DESCRIPTION
The user reported a `FOAM FATAL IO ERROR` during `snappyHexMesh` execution, specifically indicating that `Entry 'nLayerIter' not found` in `addLayersControls`.

This change adds `nLayerIter 50;` to `corkscrewFilter/system/snappyHexMeshDict` to satisfy the OpenFOAM v2406 requirement.

Verified by confirming the file content update. Full execution verification was attempted but failed due to Docker-in-Docker environment limitations in the sandbox, which are unrelated to the fix itself (the error was about overlayfs mounting). The fix directly addresses the explicit error message.

---
*PR created automatically by Jules for task [6556770431617059542](https://jules.google.com/task/6556770431617059542) started by @LokiMetaSmith*