### PR TITLE
Fix OpenFOAM v2406 snappyHexMeshDict missing parameter crash

### DIFF
--- a/corkscrewFilter/system/snappyHexMeshDict
+++ b/corkscrewFilter/system/snappyHexMeshDict
@@ -82,6 +82,9 @@ addLayersControls
     minMedianAxisAngle 90;
     nBufferCellsNoExtrude 0;
     nLayerIter 50;
+    nSmoothSurfaceNormals 1;
+    nSmoothNormals 3;
+    nSmoothThickness 10;
 }
 
 snapControls


### PR DESCRIPTION
This change addresses a crash in `snappyHexMesh` execution when using OpenFOAM v2406, which requires explicit definition of `nSmoothSurfaceNormals`. 

Changes:
- Added `nSmoothSurfaceNormals 1;` to `addLayersControls` in `corkscrewFilter/system/snappyHexMeshDict`.
- Added `nSmoothNormals 3;` and `nSmoothThickness 10;` as proactive measures for robust layer control configuration in newer OpenFOAM versions.

This fix ensures the simulation pipeline can proceed past the meshing stage in the v2406 environment.

---
*PR created automatically by Jules for task [11161129328839490155](https://jules.google.com/task/11161129328839490155) started by @LokiMetaSmith*