### PR TITLE
Fix typo in snappyHexMeshDict parameter minMedialAxisAngle

### DIFF
--- a/corkscrewFilter/system/snappyHexMeshDict
+++ b/corkscrewFilter/system/snappyHexMeshDict
@@ -79,7 +79,7 @@ addLayersControls
     featureAngle 130;
     maxFaceThicknessRatio 0.5;
     maxThicknessToMedialRatio 0.3;
-    minMedianAxisAngle 90;
+    minMedialAxisAngle 90;
     nBufferCellsNoExtrude 0;
     nLayerIter 50;
     nSmoothSurfaceNormals 1;


### PR DESCRIPTION
Corrected `minMedianAxisAngle` to `minMedialAxisAngle` in `corkscrewFilter/system/snappyHexMeshDict` to resolve a `FOAM FATAL IO ERROR` during mesh generation.

---
*PR created automatically by Jules for task [7762422113189252721](https://jules.google.com/task/7762422113189252721) started by @LokiMetaSmith*