### PR TITLE
fix: add missing nRelaxIter to snappyHexMeshDict for OpenFOAM v2406

### DIFF
--- a/corkscrewFilter/system/snappyHexMeshDict
+++ b/corkscrewFilter/system/snappyHexMeshDict
@@ -85,6 +85,7 @@ addLayersControls
     nSmoothSurfaceNormals 1;
     nSmoothNormals 3;
     nSmoothThickness 10;
+    nRelaxIter 5;
 }
 
 snapControls


### PR DESCRIPTION
Added `nRelaxIter 5;` to `addLayersControls` in `corkscrewFilter/system/snappyHexMeshDict` to resolve an OpenFOAM v2406 compatibility issue. Verified the file modification and ran SCAD regression tests (which passed except for unrelated known timeouts). OpenFOAM verification was blocked by sandbox Docker issues but the fix addresses the specific error message reported.

---
*PR created automatically by Jules for task [13514243058147803239](https://jules.google.com/task/13514243058147803239) started by @LokiMetaSmith*