### PR TITLE
Fix ModularFilterAssembly inlet alignment with helix

### DIFF
--- a/modules/assemblies.scad
+++ b/modules/assemblies.scad
@@ -77,31 +77,28 @@ module ModularFilterAssembly(tube_id, total_length) {
                                     ? threaded_inlet_flange_od + tolerance_socket_fit
                                     : barb_inlet_flange_od + tolerance_socket_fit;
 
-                                if (inlet_type == "barb") {
-                                    // Align recess with the helix interface
-                                    z_interface = is_top ? (spacer_height_mm / 2 - 1) : (-spacer_height_mm / 2 + 2);
-                                    z_recess_pos = is_top ? (spacer_height_mm / 2 - 1) : (-spacer_height_mm / 2);
-                                    ra = twist_rate * z_interface;
+                                // Align recess with the helix interface
+                                z_interface = is_top ? (spacer_height_mm / 2 - 1) : (-spacer_height_mm / 2 + 2);
+                                z_recess_pos = is_top ? (spacer_height_mm / 2 - 1) : (-spacer_height_mm / 2);
+                                ra = twist_rate * z_interface;
 
-                                    rotate([0, 0, ra]) translate([helix_path_radius_mm, 0, z_recess_pos]) cylinder(d = recess_d, h = 2);
-                                } else {
-                                    // Standard centered recess for threaded/pressfit
-                                    z_recess_pos = is_top ? (spacer_height_mm / 2 - 1) : (-spacer_height_mm / 2);
-                                    translate([0, 0, z_recess_pos]) cylinder(d = recess_d, h = 2);
-                                }
+                                rotate([0, 0, ra]) translate([helix_path_radius_mm, 0, z_recess_pos]) cylinder(d = recess_d, h = 2);
                             }
                         }
                     }
 
                     if ((is_top || is_base) && inlet_type != "none") {
                         mirror_vec = [0, 0, is_top ? 0 : 1];
-                        if (inlet_type == "threaded" || inlet_type == "pressfit") {
-                            z_shift = is_top ? spacer_height_mm / 2 : -spacer_height_mm / 2;
-                            translate([0, 0, z_shift]) mirror(mirror_vec) ThreadedInlet();
-                        } else if (inlet_type == "barb") {
-                            z_local = is_top ? (spacer_height_mm / 2 - 1) : (-spacer_height_mm / 2 + 2);
-                            ra = twist_rate * z_local;
-                            rotate([0, 0, ra]) translate([helix_path_radius_mm, 0, z_local]) mirror(mirror_vec) BarbInlet();
+
+                        z_local = is_top ? (spacer_height_mm / 2 - 1) : (-spacer_height_mm / 2 + 2);
+                        ra = twist_rate * z_local;
+
+                        rotate([0, 0, ra]) translate([helix_path_radius_mm, 0, z_local]) mirror(mirror_vec) {
+                            if (inlet_type == "threaded" || inlet_type == "pressfit") {
+                                ThreadedInlet();
+                            } else if (inlet_type == "barb") {
+                                BarbInlet();
+                            }
                         }
                     }
 


### PR DESCRIPTION
Fixed the alignment of threaded and pressfit inlets in `ModularFilterAssembly` to match the helical channel path, resolving a misalignment issue where the inlet was centered but the helix was offset. Verified with visual inspection of generated geometry.

---
*PR created automatically by Jules for task [7710709989183941265](https://jules.google.com/task/7710709989183941265) started by @LokiMetaSmith*