### PR TITLE
Fix simpleFoam SIGFPE crash by improving numerical stability

### DIFF
--- a/corkscrewFilter/system/fvSchemes
+++ b/corkscrewFilter/system/fvSchemes
@@ -29,15 +29,15 @@ divSchemes
 {
     default         none;
     div(phi,U)      bounded Gauss linearUpwind grad(U);
-    div(phi,k)      bounded Gauss linearUpwind grad(k);
-    div(phi,epsilon) bounded Gauss linearUpwind grad(epsilon);
-    div(phi,omega)  bounded Gauss linearUpwind grad(omega);
+    div(phi,k)      bounded Gauss upwind;
+    div(phi,epsilon) bounded Gauss upwind;
+    div(phi,omega)  bounded Gauss upwind;
     div((nuEff*dev2(T(grad(U))))) Gauss linear;
 }
 
 laplacianSchemes
 {
-    default         Gauss linear corrected;
+    default         Gauss linear limited corrected 0.5;
 }
 
 interpolationSchemes

--- a/corkscrewFilter/system/fvSolution
+++ b/corkscrewFilter/system/fvSolution
@@ -36,7 +36,7 @@ solvers
 
 SIMPLE
 {
-    nNonOrthogonalCorrectors 0;
+    nNonOrthogonalCorrectors 2;
     consistent      no;
     residualControl
     {
@@ -50,14 +50,14 @@ relaxationFactors
 {
     fields
     {
-        p               0.3;
+        p               0.2;
     }
     equations
     {
-        U               0.7;
-        k               0.7;
-        epsilon         0.7;
-        omega           0.7;
+        U               0.5;
+        k               0.5;
+        epsilon         0.5;
+        omega           0.5;
     }
 }
 


### PR DESCRIPTION
This PR addresses a runtime crash (`SIGFPE`) in `simpleFoam` occurring at iteration 18. The crash was traced to `Foam::fv::gaussLaplacianScheme`, indicating numerical instability likely caused by mesh non-orthogonality and aggressive discretization schemes.

Changes include:
1.  **Relaxation Factors:** Lowered relaxation factors in `fvSolution` to dampen oscillations.
2.  **Non-Orthogonal Correctors:** Increased `nNonOrthogonalCorrectors` to 2 in `fvSolution`.
3.  **Numerical Schemes:**
    *   Switched turbulence divergence schemes to `bounded Gauss upwind` (1st order) for better stability.
    *   Applied `limited corrected 0.5` to Laplacian schemes to prevent unbounded non-orthogonal corrections.

---
*PR created automatically by Jules for task [16922476646763053869](https://jules.google.com/task/16922476646763053869) started by @LokiMetaSmith*