### PR TITLE
Fix OpenFOAM solver failure by dynamically scaling blockMesh resolution

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -229,6 +229,17 @@ functions
         new_min = center - size / 2
         new_max = center + size / 2
 
+        # Calculate cell counts based on target resolution
+        target_cell_size = 1.5  # mm. Target feature size is ~1.0mm radius.
+        nx = max(1, int(math.ceil(size[0] / target_cell_size)))
+        ny = max(1, int(math.ceil(size[1] / target_cell_size)))
+        nz = max(1, int(math.ceil(size[2] / target_cell_size)))
+
+        # Ensure minimum resolution
+        nx = max(10, nx)
+        ny = max(10, ny)
+        nz = max(10, nz)
+
         vertices = [
             f"({new_min[0]} {new_min[1]} {new_min[2]})",
             f"({new_max[0]} {new_min[1]} {new_min[2]})",
@@ -249,6 +260,12 @@ functions
 
         if pattern.search(content):
             content = pattern.sub(f"vertices\n(\n    {new_vertices_str}\n);", content)
+
+        # Update blocks with calculated resolution
+        # Matches: hex (0 1 2 3 4 5 6 7) (20 20 20)
+        pattern_blocks = re.compile(r"hex\s*\([^\)]+\)\s*\(\s*\d+\s+\d+\s+\d+\s*\)", re.DOTALL)
+        if pattern_blocks.search(content):
+             content = pattern_blocks.sub(f"hex (0 1 2 3 4 5 6 7) ({nx} {ny} {nz})", content)
 
         with open(bm_path, 'w') as f:
             f.write(content)


### PR DESCRIPTION
The solver failure in the automated CFD pipeline was traced to a mismatch between the fixed background mesh resolution (`20 20 20`) and the variable geometry size, particularly for small features like the helical fluid channel (radius ~1.0mm). This coarse resolution caused `snappyHexMesh` to generate a disconnected mesh where the fluid domain did not reach the inlet/outlet boundaries, leading to the removal of these patches and subsequent solver error.

This change introduces dynamic resolution scaling in `FoamDriver.update_blockMesh`:
1.  Calculates the physical size of the block mesh from bounds and margins.
2.  Computes the required number of cells `(nx, ny, nz)` to achieve a target cell size of 1.5mm.
3.  Updates the `blocks` section of `system/blockMeshDict` with the calculated dimensions using regex.
4.  Enforces a minimum of 10 cells per dimension to prevent degenerate meshes for very small objects.

This ensures a consistent and adequate base mesh density regardless of the geometry dimensions.

---
*PR created automatically by Jules for task [872720091016424195](https://jules.google.com/task/872720091016424195) started by @LokiMetaSmith*