### PR TITLE
Fix missing slit in central bin and reduce slit length

### DIFF
--- a/config.scad
+++ b/config.scad
@@ -126,7 +126,7 @@ outer_casing_wall_mm = 3;        // The wall thickness of the hexagonal casing f
 
 // --- Slit Parameters ---
 slit_ramp_length_mm = 5;         // The length of the ramped portion of a slit (for "ramped" `slit_type`).
-slit_open_length_mm = 10;        // The length of the fully open portion of a slit.
+slit_open_length_mm = 5;         // The length of the fully open portion of a slit.
 slit_width_mm = 2;               // The width of the slit opening.
 slit_depth_mm = 2;               // The depth of the slit cut into the ramp.
 slit_axial_length_mm = 1.5;      // The height (Z-axis) of the slit cut for CorkscrewSlitKnife.

--- a/modules/assemblies.scad
+++ b/modules/assemblies.scad
@@ -51,9 +51,9 @@ module ModularFilterAssembly(tube_id, total_length) {
                         cylinder(h = bin_length + 0.1, d = tube_id * 2, center = true);
                      }
                      if (slit_type == "simple") {
-                         SimpleSlitCutter(bin_length, twist_rate * bin_length, 2 * (helix_path_radius_mm + helix_profile_radius_mm), 1);
+                         SimpleSlitCutter(bin_length, twist_rate * bin_length, 2 * (helix_path_radius_mm + helix_profile_radius_mm), 1, offset_angle=0);
                      } else if (slit_type == "ramped") {
-                         RampedSlitKnife(bin_length, twist_rate * bin_length, 2 * (helix_path_radius_mm + helix_profile_radius_mm), 1);
+                         RampedSlitKnife(bin_length, twist_rate * bin_length, 2 * (helix_path_radius_mm + helix_profile_radius_mm), 1, offset_angle=0);
                      }
                  }
             }

--- a/modules/cutters.scad
+++ b/modules/cutters.scad
@@ -9,9 +9,9 @@
  * Description: Creates a simple rectangular helical cutting tool for making slits.
  * Arguments: (Same as MultiHelixRamp)
  */
-module SimpleSlitCutter(h, twist, dia, helices) {
+module SimpleSlitCutter(h, twist, dia, helices, offset_angle=ramp_width_degrees/2) {
     for (i = [0 : helices - 1]) {
-        rotate([0, 0, i * (360 / helices) + ramp_width_degrees / 2])
+        rotate([0, 0, i * (360 / helices) + offset_angle])
         linear_extrude(height = h, twist = twist, center = true, slices = h > 0 ? h * 2 : 1)
             translate([dia / 2 - slit_depth_mm / 2, 0])
                 square([slit_depth_mm, slit_width_mm], center = true);
@@ -23,13 +23,13 @@ module SimpleSlitCutter(h, twist, dia, helices) {
  * Description: Creates a more complex cutting tool for making slits with a ramped lead-in.
  * Arguments: (Same as MultiHelixRamp)
  */
-module RampedSlitKnife(h, twist, dia, helices) {
+module RampedSlitKnife(h, twist, dia, helices, offset_angle=ramp_width_degrees/2) {
     twist_per_mm = twist / h;
     ramp_len = slit_ramp_length_mm;
     open_len = slit_open_length_mm;
 
     for (i = [0 : helices - 1]) {
-        rotate([0, 0, i * (360 / helices) + ramp_width_degrees/2]) {
+        rotate([0, 0, i * (360 / helices) + offset_angle]) {
             translate([0, 0, -h/2]) {
                 union() {
                     // 1. The Ramp using hull (interpolates between start surface and full depth)


### PR DESCRIPTION
This PR addresses two issues:
1.  **Missing Slit in Central Bin:** The central bin of the `ModularFilterAssembly` was missing its slit because the slit cutter was rotated out of alignment with the bin's helical wall. This was caused by a hardcoded rotation offset (`ramp_width_degrees/2`) in the slit cutter modules, which is appropriate for `StagedHelicalStructure` but not for the `MasterHollowHelix` based assembly.
    *   **Fix:** `SimpleSlitCutter` and `RampedSlitKnife` were refactored to accept an `offset_angle` parameter. The default remains `ramp_width_degrees/2` for backward compatibility. `ModularFilterAssembly` now calls these modules with `offset_angle=0` to ensure correct alignment.
2.  **Slits Too Long:** The user reported the slits were too long.
    *   **Fix:** `slit_open_length_mm` in `config.scad` was reduced from 10mm to 5mm.

Verified visually using `repro_slit_issue.scad` (generated `repro_slit_fixed.stl`).
Note: Regression tests for `HexFilterArray` fail with pre-existing CGAL errors unrelated to these changes.

---
*PR created automatically by Jules for task [17709259449432056004](https://jules.google.com/task/17709259449432056004) started by @LokiMetaSmith*