### PR TITLE
Fix OpenFOAM solver crash and LLM JSON parsing errors

### DIFF
--- a/corkscrewFilter/constant/kinematicCloudProperties
+++ b/corkscrewFilter/constant/kinematicCloudProperties
@@ -20,6 +20,7 @@ solution
     active          true;
     coupled         false; // One-way coupling
     transient       yes;
+    calcFrequency   1;
     cellValueSourceCorrection on;
 
     interpolationSchemes

--- a/optimizer/llm_agent.py
+++ b/optimizer/llm_agent.py
@@ -1,5 +1,6 @@
 import os
 import json
+import re
 import mimetypes
 from google import genai
 from google.genai import types
@@ -238,7 +239,11 @@ You must respond with valid JSON only.
                 # Adjust start to skip line
                 first_newline = text.find("\n", start)
                 if first_newline != -1 and first_newline < end:
-                    return text[first_newline:end].strip()
+                    text = text[first_newline:end].strip()
+
+        # Cleaning: Escape backslashes that are not part of a valid escape sequence
+        # This fixes "Invalid \escape" errors common in LLM output (e.g. file paths or LaTeX)
+        text = re.sub(r'\\(?![/u"\\bfnrt])', r'\\\\', text)
         return text.strip()
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR addresses two critical issues preventing the optimization loop from completing successfully:
1.  **OpenFOAM Solver Crash:** The `icoUncoupledKinematicParcelFoam` solver was failing with "Entry 'calcFrequency' not found". This was fixed by adding the missing parameter to `constant/kinematicCloudProperties`.
2.  **LLM Agent Failure:** The LLM agent was failing to parse JSON responses containing Windows file paths or other unescaped backslashes. A regex-based cleaning step was added to `_extract_json` to automatically repair these strings before parsing.

---
*PR created automatically by Jules for task [8959870137618997770](https://jules.google.com/task/8959870137618997770) started by @LokiMetaSmith*