### PR TITLE
Add instructions for missing GEMINI_API_KEY

### DIFF
--- a/optimizer/check_models.py
+++ b/optimizer/check_models.py
@@ -5,6 +5,7 @@ def list_models():
     api_key = os.environ.get("GEMINI_API_KEY")
     if not api_key:
         print("Error: GEMINI_API_KEY environment variable not found.")
+        print("Please export GEMINI_API_KEY='your_key_here' and try again.")
         return
 
     try:

--- a/optimizer/debug_models.py
+++ b/optimizer/debug_models.py
@@ -23,6 +23,7 @@ def debug_models():
     api_key = os.environ.get("GEMINI_API_KEY")
     if not api_key:
         print("GEMINI_API_KEY not found. Cannot perform live list.")
+        print("Please export GEMINI_API_KEY='your_key_here' and try again.")
         return
 
     client = genai.Client(api_key=api_key)

--- a/optimizer/generate_campaign.py
+++ b/optimizer/generate_campaign.py
@@ -20,6 +20,7 @@ def main():
     # Check if agent has model
     if not agent.client:
         print("Error: No LLM available (check GEMINI_API_KEY). Cannot generate campaign.")
+        print("Please export GEMINI_API_KEY='your_key_here' and try again.")
         return
 
     parameter_sets = agent.suggest_campaign(history, CONSTRAINTS, count=args.count)

--- a/optimizer/llm_agent.py
+++ b/optimizer/llm_agent.py
@@ -18,6 +18,8 @@ class LLMAgent:
 
         if not api_key:
             print("Warning: GEMINI_API_KEY not found. LLM features will be disabled.")
+            print("To use LLM features, please set the GEMINI_API_KEY environment variable.")
+            print("Example: export GEMINI_API_KEY='your_api_key_here'")
             self.client = None
         else:
             self.client = genai.Client(api_key=api_key)


### PR DESCRIPTION
Added instructions on how to set the `GEMINI_API_KEY` when it is missing in the optimizer scripts. The scripts now print `Please export GEMINI_API_KEY='your_key_here'` to the console.

---
*PR created automatically by Jules for task [15551235423744015685](https://jules.google.com/task/15551235423744015685) started by @LokiMetaSmith*