### PR TITLE
Add parameter validation to prevent invalid geometry generation

### DIFF
--- a/optimizer/parameter_validator.py
+++ b/optimizer/parameter_validator.py
@@ -1,0 +1,69 @@
+
+def validate_parameters(params):
+    """
+    Validates the geometric parameters for the corkscrew filter to prevent
+    generation of invalid or self-intersecting geometry.
+
+    Args:
+        params (dict): Dictionary of parameters (e.g., from LLM or config).
+
+    Returns:
+        tuple: (is_valid (bool), error_message (str or None))
+    """
+    try:
+        # Extract parameters with defaults matching config.scad where appropriate
+        # Dimensions
+        tube_od = float(params.get("tube_od_mm", 32))
+        tube_wall = float(params.get("tube_wall_mm", 1.5))
+
+        path_r = float(params.get("helix_path_radius_mm", 1.8))
+        profile_r = float(params.get("helix_profile_radius_mm", 1.8))
+        void_r = float(params.get("helix_void_profile_radius_mm", 1.0))
+
+        # 1. Check for valid positive dimensions
+        if tube_od <= 0 or tube_wall <= 0:
+            return False, f"Tube dimensions must be positive. Got OD={tube_od}, Wall={tube_wall}"
+
+        if path_r <= 0 or profile_r <= 0 or void_r <= 0:
+            return False, f"Helix dimensions must be positive. Got Path={path_r}, Profile={profile_r}, Void={void_r}"
+
+        # 2. Check for Self-Intersection at Center
+        # The profile is centered at x=path_r. If profile_r > path_r, it crosses x=0.
+        # When twisted, this creates a self-intersecting geometry.
+        if profile_r > path_r:
+            return False, (
+                f"Invalid Geometry: Helix profile radius ({profile_r}mm) is larger than "
+                f"helix path radius ({path_r}mm). This causes self-intersection at the center axis."
+            )
+
+        # 3. Check for Wall Thickness (Solid vs Void)
+        # We need some wall thickness.
+        if void_r >= profile_r:
+             return False, (
+                f"Invalid Geometry: Void radius ({void_r}mm) is >= Profile radius ({profile_r}mm). "
+                "This results in zero or negative wall thickness."
+            )
+
+        # 4. Check for Tube Fit
+        # The outer radius of the helix is path_r + profile_r.
+        # It must fit inside the tube inner radius (tube_od/2 - tube_wall).
+        tube_id_radius = (tube_od / 2.0) - tube_wall
+        helix_outer_radius = path_r + profile_r
+
+        # Allow a small tolerance/clearance, but strictly it shouldn't be larger.
+        # If it's larger, it intersects the tube.
+        if helix_outer_radius > tube_id_radius:
+             return False, (
+                f"Invalid Geometry: Helix outer radius ({helix_outer_radius:.2f}mm) exceeds "
+                f"tube inner radius ({tube_id_radius:.2f}mm). It will intersect the tube wall."
+            )
+
+        # 5. Check Insert Length
+        length = float(params.get("insert_length_mm", 50))
+        if length <= 0:
+             return False, f"Insert length must be positive. Got {length}"
+
+        return True, None
+
+    except (ValueError, TypeError) as e:
+        return False, f"Parameter type error: {e}"

--- a/optimizer/simulation_runner.py
+++ b/optimizer/simulation_runner.py
@@ -2,6 +2,7 @@ import os
 import time
 import math
 from utils import Timer
+from parameter_validator import validate_parameters
 
 def run_simulation(scad_driver, foam_driver, params, output_stl_name="corkscrew_fluid.stl", dry_run=False, skip_cfd=False, iteration=0, reuse_mesh=False):
     """
@@ -37,6 +38,12 @@ def run_simulation(scad_driver, foam_driver, params, output_stl_name="corkscrew_
     mesh_log = os.path.join(log_dir, "meshing.log")
     solver_log = os.path.join(log_dir, "solver.log")
     vis_log = os.path.join(log_dir, "visualization.log")
+
+    # 0. Validate Parameters
+    is_valid, error_msg = validate_parameters(params)
+    if not is_valid:
+        print(f"Parameter Validation Failed: {error_msg}")
+        return {"error": "invalid_parameters", "details": error_msg}, []
 
     # 1. Generate Geometry (Fluid Volume for CFD)
     stl_path = os.path.join(foam_driver.case_dir, "constant", "triSurface", output_stl_name)

--- a/test/test_parameter_validator.py
+++ b/test/test_parameter_validator.py
@@ -1,0 +1,84 @@
+import unittest
+import sys
+import os
+
+# Ensure we can import from optimizer
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'optimizer')))
+
+from parameter_validator import validate_parameters
+
+class TestParameterValidator(unittest.TestCase):
+    def setUp(self):
+        # Baseline valid parameters (from config.scad defaults)
+        self.base_params = {
+            "tube_od_mm": 32,
+            "tube_wall_mm": 1.5,
+            "helix_path_radius_mm": 1.8,
+            "helix_profile_radius_mm": 1.8,
+            "helix_void_profile_radius_mm": 1.0,
+            "insert_length_mm": 50
+        }
+
+    def test_valid_parameters(self):
+        is_valid, msg = validate_parameters(self.base_params)
+        self.assertTrue(is_valid, f"Expected valid, got invalid: {msg}")
+
+    def test_self_intersection_center(self):
+        # Profile larger than path -> crosses center axis
+        params = self.base_params.copy()
+        params["helix_path_radius_mm"] = 1.8
+        params["helix_profile_radius_mm"] = 2.5 # > 1.8
+
+        is_valid, msg = validate_parameters(params)
+        self.assertFalse(is_valid)
+        self.assertIn("self-intersection", msg.lower())
+
+    def test_wall_thickness(self):
+        # Void >= Profile -> no wall
+        params = self.base_params.copy()
+        params["helix_profile_radius_mm"] = 1.5
+        params["helix_void_profile_radius_mm"] = 1.5
+
+        is_valid, msg = validate_parameters(params)
+        self.assertFalse(is_valid)
+        self.assertIn("wall thickness", msg.lower())
+
+    def test_tube_fit(self):
+        # Helix too big for tube
+        # Tube ID radius = (32/2) - 1.5 = 16 - 1.5 = 14.5
+        params = self.base_params.copy()
+        params["helix_path_radius_mm"] = 10
+        params["helix_profile_radius_mm"] = 5
+        # Outer radius = 15 > 14.5
+
+        is_valid, msg = validate_parameters(params)
+        self.assertFalse(is_valid)
+        self.assertIn("intersect the tube", msg.lower())
+
+    def test_negative_dimensions(self):
+        params = self.base_params.copy()
+        params["insert_length_mm"] = -10
+        is_valid, msg = validate_parameters(params)
+        self.assertFalse(is_valid)
+        self.assertIn("positive", msg.lower())
+
+    def test_user_failure_case(self):
+        # specific case from user report
+        params = {
+            'part_to_generate': 'modular_filter_assembly',
+            'num_bins': 1,
+            'number_of_complete_revolutions': 2,
+            'helix_path_radius_mm': 1.8,
+            'helix_profile_radius_mm': 2.5,
+            'helix_void_profile_radius_mm': 1.0,
+            'helix_profile_scale_ratio': 1.4,
+            'tube_od_mm': 32,
+            'insert_length_mm': 50,
+            'GENERATE_CFD_VOLUME': True
+        }
+        is_valid, msg = validate_parameters(params)
+        self.assertFalse(is_valid)
+        self.assertIn("self-intersection", msg.lower())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR introduces a parameter validation step to the optimization pipeline. 

**Problem:**
Previously, the system would attempt to generate geometry and mesh it even if the parameters were physically impossible or resulted in self-intersecting geometry (e.g., `helix_profile_radius` > `helix_path_radius`). This led to long runtime failures in `snappyHexMesh` with cryptic error messages.

**Solution:**
A new `parameter_validator.py` module checks for:
1.  **Self-Intersection:** Ensures the helical profile does not overlap the central axis (`profile_r <= path_r`).
2.  **Wall Thickness:** Ensures `void_r < profile_r`.
3.  **Tube Fit:** Ensures the helix fits within the tube (with a warning/error if it intersects).
4.  **Positive Dimensions:** Checks for non-positive lengths or radii.

This validator is called at the beginning of `run_simulation`. If validation fails, the function returns an error metric immediately, skipping the expensive steps and allowing the optimizer to record the failure and move on.

**Verification:**
- Added `test/test_parameter_validator.py` covering various failure modes and the specific case reported by the user.
- Verified integration with a reproduction script.

---
*PR created automatically by Jules for task [15395394280207759731](https://jules.google.com/task/15395394280207759731) started by @LokiMetaSmith*