### PR TITLE
Fix invalid geometry parameters in optimizer

### DIFF
--- a/optimizer/constraints.py
+++ b/optimizer/constraints.py
@@ -7,6 +7,7 @@ CONSTRAINTS = """
     - insert_length_mm should be around 50.
     - helix_path_radius_mm > helix_void_profile_radius_mm (to ensure structural integrity if solid, but for fluid volume this defines the channel).
     - helix_profile_radius_mm must be > helix_void_profile_radius_mm (e.g., by at least 1mm) to generate valid geometry.
+    - helix_profile_radius_mm must be <= helix_path_radius_mm to prevent self-intersection at the center axis.
     - num_bins should be integer >= 1.
     - Optimization Goal: Maximize particle collection efficiency (trap moon dust) while minimizing pressure drop.
     - Consider increasing number_of_complete_revolutions to increase centrifugal force.

--- a/optimizer/llm_agent.py
+++ b/optimizer/llm_agent.py
@@ -97,8 +97,9 @@ class LLMAgent:
         path_radius = round(random.uniform(max(1.5, void_radius + 0.5), 5.0), 2)
         new_params["helix_path_radius_mm"] = path_radius
 
-        # helix_profile_radius_mm: > void + 0.5
-        profile_radius = round(random.uniform(max(1.5, void_radius + 0.5), 5.0), 2)
+        # helix_profile_radius_mm: > void + 0.5 AND <= path_radius
+        min_profile = max(1.5, void_radius + 0.5)
+        profile_radius = round(random.uniform(min_profile, path_radius), 2)
         new_params["helix_profile_radius_mm"] = profile_radius
 
         # helix_profile_scale_ratio: 1.0 - 2.0

--- a/optimizer/main.py
+++ b/optimizer/main.py
@@ -54,7 +54,7 @@ def main():
         "num_bins": 1,
         "number_of_complete_revolutions": 2,
         "helix_path_radius_mm": 1.8,
-        "helix_profile_radius_mm": 2.5,
+        "helix_profile_radius_mm": 1.8,
         "helix_void_profile_radius_mm": 1.0,
         "helix_profile_scale_ratio": 1.4,
         "tube_od_mm": 32,


### PR DESCRIPTION
This PR fixes a critical issue where the optimizer would generate invalid geometry parameters (specifically `helix_profile_radius_mm > helix_path_radius_mm`), causing self-intersection and validation failures.

Changes:
1.  **`optimizer/main.py`**: Corrected the hardcoded initial `helix_profile_radius_mm` from 2.5 to 1.8 to match `helix_path_radius_mm`.
2.  **`optimizer/llm_agent.py`**: Modified `_generate_random_parameters` to ensure the generated `helix_profile_radius_mm` is always less than or equal to `helix_path_radius_mm`.
3.  **`optimizer/constraints.py`**: Added an explicit textual constraint about self-intersection to guide the LLM.

Verified with a dry-run optimization loop (`--dry-run --no-llm`), confirming that both the initial parameters and randomly generated parameters pass validation and successfully trigger the simulation pipeline.

---
*PR created automatically by Jules for task [15657064211877262577](https://jules.google.com/task/15657064211877262577) started by @LokiMetaSmith*