### PR TITLE
Fix dependency installation and driver selection logic

### DIFF
--- a/optimizer/scad_driver.py
+++ b/optimizer/scad_driver.py
@@ -9,9 +9,19 @@ from utils import run_command_with_spinner
 class ScadDriver:
     def __init__(self, scad_file_path, force_native=False):
         self.scad_file_path = scad_file_path
-        # User requested favoring export.js.
-        # Only use native if explicitly forced or if node is missing (unlikely in this env).
-        self.use_native = force_native and (shutil.which("openscad") is not None)
+
+        has_native = shutil.which("openscad") is not None
+        has_node = shutil.which("node") is not None
+
+        # Determine preference:
+        # Default to WASM (use_native=False) unless forced or Node is missing.
+        self.use_native = False
+
+        if force_native and has_native:
+            self.use_native = True
+        elif not has_node and has_native:
+            # Fallback to native if node is missing but native exists
+            self.use_native = True
 
         if self.use_native:
             print("Using Native OpenSCAD.")

--- a/start_optimization.sh
+++ b/start_optimization.sh
@@ -4,20 +4,24 @@ set -e
 echo "=== Corkscrew Filter Optimization Startup ==="
 
 # 1. Check Dependencies
-if ! command -v openscad &> /dev/null; then
-    if ! command -v node &> /dev/null; then
-        echo "Error: Neither 'openscad' nor 'node' found. Please install one of them."
-        exit 1
-    else
-        echo "Native OpenSCAD not found, will use Node.js fallback (openscad-wasm)."
-        # Ensure dependencies for export.js are installed
-        if [ ! -d "node_modules" ]; then
+HAS_OPENSCAD=false
+if command -v openscad &> /dev/null; then
+    echo "Found native OpenSCAD."
+    HAS_OPENSCAD=true
+fi
+
+# Always check for Node and install deps if needed (even if OpenSCAD is present)
+if command -v node &> /dev/null; then
+    # Ensure dependencies for export.js are installed if package.json exists
+    if [ -f "package.json" ]; then
+         if [ ! -d "node_modules" ]; then
             echo "Installing Node.js dependencies..."
             npm install
-        fi
+         fi
     fi
-else
-    echo "Found native OpenSCAD."
+elif [ "$HAS_OPENSCAD" = false ]; then
+    echo "Error: Neither 'openscad' nor 'node' found. Please install one of them."
+    exit 1
 fi
 
 # 2. Check API Key


### PR DESCRIPTION
This change fixes a critical issue where the optimization loop would fail to generate geometry when the Node.js/WASM driver was selected (default) but dependencies were missing because the startup script skipped `npm install` upon detecting native OpenSCAD.

Changes:
- `start_optimization.sh`: Decoupled `npm install` from OpenSCAD detection. Now always checks for `node` and `package.json` and installs dependencies if needed.
- `optimizer/scad_driver.py`: Improved driver selection logic to correctly identify available tools and fallback to native OpenSCAD if Node is missing, preventing crashes.

Verified by reproducing the `MODULE_NOT_FOUND` error with a mock OpenSCAD executable and confirming the fix installs dependencies and allows execution to proceed.

---
*PR created automatically by Jules for task [12044348028285514650](https://jules.google.com/task/12044348028285514650) started by @LokiMetaSmith*