### PR TITLE
Fix geometry generation crash and driver dependency logic

### DIFF
--- a/optimizer/main.py
+++ b/optimizer/main.py
@@ -54,7 +54,7 @@ def main():
         "num_bins": 1,
         "number_of_complete_revolutions": 2,
         "helix_path_radius_mm": 1.8,
-        "helix_profile_radius_mm": 1.8,
+        "helix_profile_radius_mm": 1.7, # Reduced from 1.8 to avoid center singularity (WASM crash)
         "helix_void_profile_radius_mm": 1.0,
         "helix_profile_scale_ratio": 1.4,
         "tube_od_mm": 32,

--- a/optimizer/parameter_validator.py
+++ b/optimizer/parameter_validator.py
@@ -30,10 +30,12 @@ def validate_parameters(params):
         # 2. Check for Self-Intersection at Center
         # The profile is centered at x=path_r. If profile_r > path_r, it crosses x=0.
         # When twisted, this creates a self-intersecting geometry.
-        if profile_r > path_r:
+        # Additionally, for WASM/CGAL stability, we strictly require profile_r < path_r
+        # to avoid grazing contact singularities at x=0.
+        if profile_r >= path_r:
             return False, (
-                f"Invalid Geometry: Helix profile radius ({profile_r}mm) is larger than "
-                f"helix path radius ({path_r}mm). This causes self-intersection at the center axis."
+                f"Invalid Geometry: Helix profile radius ({profile_r}mm) must be strictly less than "
+                f"helix path radius ({path_r}mm) to avoid center-axis singularity."
             )
 
         # 3. Check for Wall Thickness (Solid vs Void)

--- a/test/test_parameter_validator.py
+++ b/test/test_parameter_validator.py
@@ -10,11 +10,12 @@ from parameter_validator import validate_parameters
 class TestParameterValidator(unittest.TestCase):
     def setUp(self):
         # Baseline valid parameters (from config.scad defaults)
+        # Updated to 1.7 profile radius to avoid center singularity (strictly < path 1.8)
         self.base_params = {
             "tube_od_mm": 32,
             "tube_wall_mm": 1.5,
             "helix_path_radius_mm": 1.8,
-            "helix_profile_radius_mm": 1.8,
+            "helix_profile_radius_mm": 1.7,
             "helix_void_profile_radius_mm": 1.0,
             "insert_length_mm": 50
         }
@@ -31,7 +32,8 @@ class TestParameterValidator(unittest.TestCase):
 
         is_valid, msg = validate_parameters(params)
         self.assertFalse(is_valid)
-        self.assertIn("self-intersection", msg.lower())
+        # Updated error message check
+        self.assertTrue("singularity" in msg.lower() or "self-intersection" in msg.lower())
 
     def test_wall_thickness(self):
         # Void >= Profile -> no wall
@@ -78,7 +80,8 @@ class TestParameterValidator(unittest.TestCase):
         }
         is_valid, msg = validate_parameters(params)
         self.assertFalse(is_valid)
-        self.assertIn("self-intersection", msg.lower())
+        # Updated error message check
+        self.assertTrue("singularity" in msg.lower() or "self-intersection" in msg.lower())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Updated `optimizer/main.py` to use a safe initial `helix_profile_radius_mm` (1.7mm) to avoid center-axis singularity.
- Updated `optimizer/parameter_validator.py` to enforce strict inequality `profile_r < path_r` for WASM stability.
- Modified `start_optimization.sh` to robustly install Node dependencies if Node is present.
- Improved `optimizer/scad_driver.py` selection logic to handle missing Node environments.
- Updated unit tests in `test/test_parameter_validator.py`.