### PR TITLE
Fix meshing resolution failure and improve particle tracking metrics

### DIFF
--- a/optimizer/simulation_runner.py
+++ b/optimizer/simulation_runner.py
@@ -139,10 +139,21 @@ def run_simulation(scad_driver, foam_driver, params, output_stl_name="corkscrew_
                 calculated_limit = int(ram_gb * 25000)
 
                 # Clamp limits
-                MIN_LIMIT = 50_000
+                MIN_LIMIT = 100_000
                 MAX_LIMIT = 500_000 # Cap at 500k to avoid excessive runtimes even on big machines
 
                 MAX_CELLS = max(MIN_LIMIT, min(calculated_limit, MAX_LIMIT))
+
+                # Check for minimum resolution requirement (void_r)
+                if void_r:
+                    # Require at least 4 cells across the channel diameter (radius / 2)
+                    # This ensures features aren't completely lost
+                    min_res_cell_size = (float(void_r) * SCALE_FACTOR) / 2.0
+                    min_required_cells = block_volume / (min_res_cell_size ** 3)
+
+                    if min_required_cells > MAX_CELLS:
+                        print(f"Warning: Minimum resolution requires ~{min_required_cells:.0f} cells, which exceeds memory limit {MAX_CELLS}. Ignoring memory limit to preserve geometry.")
+                        MAX_CELLS = int(min_required_cells)
 
                 if estimated_cells > MAX_CELLS:
                     new_size = (block_volume / MAX_CELLS) ** (1/3)


### PR DESCRIPTION
This PR addresses the user's issue where `snappyHexMesh` failed with "Patch 'inlet' not found" due to overly aggressive memory optimization reducing the mesh resolution below what is needed to capture small features.

Key changes:
- **Mesh Resolution:** The simulation runner now calculates a hard floor for mesh resolution based on the channel geometry (`helix_void_profile_radius_mm`). If the memory-based limit (`MAX_CELLS`) is too low, it is overridden (with a warning) to ensure the mesh is valid.
- **Particle Tracking:** The foam driver now parses the explicit "Parcel fate" table to distinguish between particles that escaped the domain and those that stuck to walls or remained in the bin volume, providing the requested "total particulate" metrics.

---
*PR created automatically by Jules for task [3781499090562886956](https://jules.google.com/task/3781499090562886956) started by @LokiMetaSmith*