### PR TITLE
Add configurable tube visualization to filter assemblies

### DIFF
--- a/config.scad
+++ b/config.scad
@@ -31,6 +31,7 @@ ADD_DEBRIS_EXIT_CHANNELS = true; // NEW: If true, cuts channels for debris to ex
 
 // --- Visual/Debug Options ---
 SHOW_O_RINGS = true;             // If true, renders red O-rings in their grooves for visualization.
+SHOW_TUBE = true;                // If true, renders a translucent tube around the filter for visualization.
 USE_TRANSLUCENCY = true;        // If true, makes certain parts semi-transparent to see internal geometry.
 CUT_FOR_VISIBILITY = false;      // If true, cuts the model in half (removes Y>0) to allow inspection of internal geometry.
 
@@ -50,6 +51,7 @@ $fn = $preview ? low_res_fn : _actual_high_res_fn; // OpenSCAD automatically use
 // --- Tube & Main Assembly Parameters ---
 tube_od_mm = 32;                 // The outer diameter of the tube the filter assembly will be inserted into.
 tube_wall_mm = 1;                // The wall thickness of the tube. Used to calculate the inner diameter.
+tube_length_override = 0;        // Custom length for the visualized tube (0 = auto/match component).
 insert_length_mm = 50 ;      // The total length of the filter insert from end to end.
 num_bins = 3;                    // The number of separate helical screw segments in the modular assembly.
 

--- a/modules/assemblies.scad
+++ b/modules/assemblies.scad
@@ -115,6 +115,13 @@ module ModularFilterAssembly(tube_id, total_length) {
                 }
             }
         }
+
+        if (SHOW_TUBE) {
+            visual_tube_len = (tube_length_override > total_length) ? tube_length_override : total_length;
+            // tube_id is passed as arg, which corresponds to the inner diameter of the tube.
+            // We reconstruct the OD using the global tube_wall_mm.
+            TubeVisualizer(tube_id + 2 * tube_wall_mm, tube_wall_mm, visual_tube_len, center = true);
+        }
     }
 }
 
@@ -273,6 +280,12 @@ module HoseAdapterEndCap(tube_od, hose_id, oring_cs, tube_wall = tube_wall_mm, a
             translate([0, 0, cap_sleeve_height - groove_depth / 2]) OringVisualizer_Face(groove_center_dia, oring_cs);
         }
 
+        if (SHOW_TUBE) {
+            visual_tube_len = (tube_length_override > 0) ? tube_length_override : (cap_sleeve_height + 50);
+            translate([0, 0, cap_sleeve_height - visual_tube_len / 2])
+                TubeVisualizer(tube_od, tube_wall, visual_tube_len, center = true);
+        }
+
         translate([0, 0, cap_sleeve_height + cap_end_plate_thick + flange_height])
             Barb(hose_id = hose_id, hose_od = hose_id + 1.5, barb_count = 4);
 
@@ -296,6 +309,12 @@ module HoseAdapterEndCap(tube_od, hose_id, oring_cs, tube_wall = tube_wall_mm, a
 
         if (SHOW_O_RINGS) {
             translate([0, 0, cap_sleeve_height / 2]) OringVisualizer_ID(cap_inner_dia, oring_cs);
+        }
+
+        if (SHOW_TUBE) {
+            visual_tube_len = (tube_length_override > 0) ? tube_length_override : (cap_sleeve_height + 50);
+            translate([0, 0, cap_sleeve_height - visual_tube_len / 2])
+                TubeVisualizer(tube_od, tube_wall, visual_tube_len, center = true);
         }
 
         translate([0, 0, cap_sleeve_height + cap_end_plate_thick + flange_height])

--- a/modules/primitives.scad
+++ b/modules/primitives.scad
@@ -111,4 +111,19 @@ module OringGroove_Face_Cutter(groove_center_dia, oring_cs) {
     rotate_extrude(convexity = 10) translate([groove_center_dia / 2, 0, 0]) square([groove_width, groove_depth], center = true);
 }
 
-
+/**
+ * Module: TubeVisualizer
+ * Description: Renders a translucent tube for visualization purposes.
+ * Arguments:
+ * tube_od:   The outer diameter of the tube.
+ * tube_wall: The wall thickness of the tube.
+ * length:    The length of the tube section to render.
+ * center:    (boolean) If true, centers the tube on the Z-axis. Default: true.
+ */
+module TubeVisualizer(tube_od, tube_wall, length, center=true) {
+    color([0.6, 0.8, 1.0, 0.3]) // Light Blue, Translucent
+    difference() {
+        cylinder(d = tube_od, h = length, center = center);
+        cylinder(d = tube_od - 2 * tube_wall, h = length + 1, center = center);
+    }
+}


### PR DESCRIPTION
This PR adds a toggleable, translucent tube visualization around the filter assembly and hose adapter cap. This allows users to visually verify the fit of the components within the tube and export the tube geometry for CFD analysis if needed. The tube length is automatically determined based on the component size but can be overridden via `tube_length_override` in `config.scad`.

---
*PR created automatically by Jules for task [15892098985349456383](https://jules.google.com/task/15892098985349456383) started by @LokiMetaSmith*