### PR TITLE
Fix missing maxTrackTime in kinematicCloudProperties

### DIFF
--- a/corkscrewFilter/constant/kinematicCloudProperties
+++ b/corkscrewFilter/constant/kinematicCloudProperties
@@ -20,6 +20,7 @@ solution
     active          true;
     coupled         false; // One-way coupling
     transient       yes;
+    maxTrackTime    10.0;
     calcFrequency   1;
     cellValueSourceCorrection on;
 


### PR DESCRIPTION
The optimization loop was failing at the particle tracking step with `FOAM FATAL IO ERROR: Entry 'maxTrackTime' not found`. This was because the steady-state flow field (from `simpleFoam`) triggered steady-state particle tracking in `icoUncoupledKinematicParcelFoam`, which mandates a `maxTrackTime` limit.

I added `maxTrackTime 10.0;` to `corkscrewFilter/constant/kinematicCloudProperties` to fix this configuration error. The value of 10 seconds is sufficient for particles to traverse the small domain (~50mm length) given typical velocities (~5 m/s).

---
*PR created automatically by Jules for task [14867713418569447590](https://jules.google.com/task/14867713418569447590) started by @LokiMetaSmith*