### PR TITLE
Fix OpenFOAM parcelBasisType error

### DIFF
--- a/corkscrewFilter/constant/kinematicCloudProperties
+++ b/corkscrewFilter/constant/kinematicCloudProperties
@@ -64,6 +64,7 @@ subModels
         {
             type            patchInjection;
             patchName       inlet;
+            parcelBasisType number;
             parcelsPerSecond 1000;
             duration        1; // Inject for 1 second
             noi             1;


### PR DESCRIPTION
The `icoUncoupledKinematicParcelFoam` solver was failing with a `FOAM FATAL IO ERROR` because `parcelBasisType` was missing in the `patchInjection` configuration. OpenFOAM v2406 requires this parameter to determine how the injection rate is calculated.

This change adds `parcelBasisType number;` to the `model1` injection dictionary in `corkscrewFilter/constant/kinematicCloudProperties`, which correctly instructs the solver to use the existing `parcelsPerSecond` setting.

Verified by code review and regression testing (python validator passed; unrelated SCAD generation timeouts persist in `npm test`).

---
*PR created automatically by Jules for task [2908437563477649686](https://jules.google.com/task/2908437563477649686) started by @LokiMetaSmith*