### PR TITLE
Fix OpenFOAM patchInjection IO error by renaming patchName to patch

### DIFF
--- a/corkscrewFilter/constant/kinematicCloudProperties
+++ b/corkscrewFilter/constant/kinematicCloudProperties
@@ -63,7 +63,7 @@ subModels
         model1
         {
             type            patchInjection;
-            patchName       inlet;
+            patch           inlet;
             parcelBasisType number;
             parcelsPerSecond 1000;
             duration        1; // Inject for 1 second


### PR DESCRIPTION
The `icoUncoupledKinematicParcelFoam` solver in OpenFOAM v2406 fails with a fatal IO error because the `patchInjection` model expects the `patch` keyword instead of the older `patchName` keyword.

This commit updates `corkscrewFilter/constant/kinematicCloudProperties` to use `patch inlet;` instead of `patchName inlet;` within the `model1` injection model configuration. This resolves the error `Entry 'patch' not found in dictionary` during particle injection construction.

---
*PR created automatically by Jules for task [2038567485180454959](https://jules.google.com/task/2038567485180454959) started by @LokiMetaSmith*