### PR TITLE
Fix OpenFOAM v2406 patchInjection missing flowRateProfile

### DIFF
--- a/corkscrewFilter/constant/kinematicCloudProperties
+++ b/corkscrewFilter/constant/kinematicCloudProperties
@@ -69,6 +69,7 @@ subModels
             duration        1; // Inject for 1 second
             noi             1;
             massFlowRate    1e-5;
+            flowRateProfile constant 1;
             U0              (0 0 5);
             sizeDistribution
             {


### PR DESCRIPTION
The `patchInjection` model in OpenFOAM v2406 requires a `flowRateProfile` entry (of type `Function1`) to define the temporal injection rate profile. The previous configuration lacked this entry, causing a "FOAM FATAL IO ERROR".

This change adds `flowRateProfile constant 1;` to the `model1` dictionary in `corkscrewFilter/constant/kinematicCloudProperties`, which configures a constant injection rate consistent with the existing `massFlowRate` and `parcelsPerSecond` settings.


---
*PR created automatically by Jules for task [1298059285207249218](https://jules.google.com/task/1298059285207249218) started by @LokiMetaSmith*