### PR TITLE
Fix OpenFOAM patchInteractionModel IO Error

### DIFF
--- a/corkscrewFilter/constant/kinematicCloudProperties
+++ b/corkscrewFilter/constant/kinematicCloudProperties
@@ -85,9 +85,10 @@ subModels
 
     dispersionModel none;
 
-    patchInteractionModel
+    patchInteractionModel localInteraction;
+
+    localInteractionCoeffs
     {
-        type localInteraction;
         patches
         (
             corkscrew


### PR DESCRIPTION
Updated `corkscrewFilter/constant/kinematicCloudProperties` to use the correct syntax for `patchInteractionModel` in OpenFOAM v2406.
Changed `patchInteractionModel` from a dictionary to a primitive type definition (`localInteraction`) and moved the configuration to `localInteractionCoeffs`.

---
*PR created automatically by Jules for task [16953604984243178064](https://jules.google.com/task/16953604984243178064) started by @LokiMetaSmith*