### PR TITLE
Update .gitignore for OpenFOAM and Mintty artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ logs/
 corkscrewFilter/constant/extendedFeatureEdgeMesh/
 corkscrewFilter/constant/polyMesh/
 corkscrewFilter/constant/triSurface/*.eMesh
+
+# Ignore OpenFOAM simulation time directories (start with non-zero digit)
+corkscrewFilter/[1-9]*
+# Ignore Mintty terminal screenshots
+mintty*.png


### PR DESCRIPTION
Added rules to .gitignore to exclude OpenFOAM time directories (e.g., 50, 100) and Mintty terminal screenshots (mintty*.png).

---
*PR created automatically by Jules for task [1343982967405174336](https://jules.google.com/task/1343982967405174336) started by @LokiMetaSmith*