### PR TITLE
Add collisionModel to kinematicCloudProperties

### DIFF
--- a/corkscrewFilter/constant/kinematicCloudProperties
+++ b/corkscrewFilter/constant/kinematicCloudProperties
@@ -106,6 +106,8 @@ subModels
         );
     }
 
+    collisionModel none;
+
     stochasticCollisionModel none;
 
     surfaceFilmModel none;


### PR DESCRIPTION
The user reported a `FOAM FATAL IO ERROR` in `icoUncoupledKinematicParcelFoam` due to missing `collisionModel` entry in `kinematicCloudProperties`.
This change adds `collisionModel none;` to the `subModels` dictionary in `corkscrewFilter/constant/kinematicCloudProperties` to fix the error.

---
*PR created automatically by Jules for task [14470906168569230751](https://jules.google.com/task/14470906168569230751) started by @LokiMetaSmith*