### PR TITLE
Fix icoUncoupledKinematicParcelFoam failure by adding stochasticCollisionModel

### DIFF
--- a/corkscrewFilter/constant/kinematicCloudProperties
+++ b/corkscrewFilter/constant/kinematicCloudProperties
@@ -59,6 +59,7 @@ subModels
     }
 
     collisionModel none;
+    stochasticCollisionModel none;
 
     injectionModels
     {


### PR DESCRIPTION
This PR addresses a fatal error encountered when running `icoUncoupledKinematicParcelFoam` (OpenFOAM v2406). The solver fails with `Entry 'stochasticCollisionModel' not found` despite the presence of `collisionModel none;`.

Changes:
- Modified `corkscrewFilter/constant/kinematicCloudProperties`:
  - Added `stochasticCollisionModel none;` inside the `subModels` dictionary.
  - Kept `collisionModel none;` for compatibility.

This fix ensures the dictionary satisfies the solver's parsing requirements, allowing particle tracking to proceed.

---
*PR created automatically by Jules for task [7946587952912995803](https://jules.google.com/task/7946587952912995803) started by @LokiMetaSmith*