### PR TITLE
Fix: Disable visual tube during CFD volume generation to prevent mesh artifacts

### DIFF
--- a/optimizer/scad_driver.py
+++ b/optimizer/scad_driver.py
@@ -80,6 +80,10 @@ class ScadDriver:
                  # Disable visibility cut for CFD volume to save processing time
                  run_params["CUT_FOR_VISIBILITY"] = "false"
 
+             # Disable visual tube generation to prevent coincident faces on fluid boundary
+             if "SHOW_TUBE" not in run_params:
+                 run_params["SHOW_TUBE"] = "false"
+
         # Limit resolution to prevent OOM/Timeouts if not specified
         if "high_res_fn" not in run_params:
              run_params["high_res_fn"] = 100


### PR DESCRIPTION
The user reported an issue with the STL file used for modeling flow, providing an image showing red patches on the cylinder surface, likely indicating mesh artifacts.
Investigation revealed that `ModularFilterAssembly` generates a "Visual Tube" (translucent cylinder) by default (`SHOW_TUBE=true` in `config.scad`).
When generating the CFD fluid volume, `corkscrew.scad` subtracts the filter assembly from a solid cylinder representing the fluid.
Since the Visual Tube acts as the container wall, its inner surface is coincident with the fluid cylinder's outer surface.
Subtracting the Visual Tube from the Fluid Cylinder (which are disjoint except at the boundary) is mathematically redundant but can cause coincident face artifacts (z-fighting/degenerate triangles) in the resulting STL, which `snappyHexMesh` may struggle to handle cleanly.

This change modifies `optimizer/scad_driver.py` to explicitly inject `SHOW_TUBE="false"` into the OpenSCAD parameters when `GENERATE_CFD_VOLUME` is set to "true". This ensures the visual tube is not generated during the CFD volume creation step, producing a cleaner STL for meshing.

Verification confirmed that the flag is correctly passed to the OpenSCAD command.

---
*PR created automatically by Jules for task [14514572111075611424](https://jules.google.com/task/14514572111075611424) started by @LokiMetaSmith*