### PR TITLE
Fix icoUncoupledKinematicParcelFoam segfault in particle tracking

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -671,7 +671,7 @@ patches
             parcelsPerSecond 200; // Total ~1000/s across 5 bins
             duration        1;
             SOI             0;
-            noi             1;
+            nParticle       1;
             massFlowRate    2e-6; // Approximate
             flowRateProfile constant 1;
             U0              (0 0 5);


### PR DESCRIPTION
Fixes a segmentation fault in `icoUncoupledKinematicParcelFoam` during particle tracking.
The crash was caused by an incorrect `patchInjection` configuration in `optimizer/foam_driver.py`:
- Replaced the invalid `noi` parameter (Number of Injections, used in ConeInjection) with `nParticle` (required for `parcelBasisType number`).
- This ensures proper initialization of parcels and prevents the solver from accessing uninitialized memory.
Verified by generating the configuration file and confirming the correct keywords are present.

---
*PR created automatically by Jules for task [7000736238054942196](https://jules.google.com/task/7000736238054942196) started by @LokiMetaSmith*