### PR TITLE
Add verbose logging and strict memory enforcement for OpenFOAM runs

### DIFF
--- a/optimizer/main.py
+++ b/optimizer/main.py
@@ -42,6 +42,7 @@ def main():
     parser.add_argument("--no-llm", action="store_true", help="Explicitly disable LLM and use random/fallback strategy (also suppresses prompts in startup script)")
     parser.add_argument("--batch-size", type=int, default=5, help="Number of parameter sets to generate per LLM call")
     parser.add_argument("--no-cleanup", action="store_true", help="Disable cleanup of artifacts (STLs, images) for non-top runs")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Enable verbose output (e.g. error logs)")
     args = parser.parse_args()
 
     # Parse iterations argument
@@ -61,7 +62,7 @@ def main():
 
     # Initialize components
     scad = ScadDriver(args.scad_file)
-    foam = FoamDriver(args.case_dir, container_engine=args.container_engine, num_processors=args.cpus)
+    foam = FoamDriver(args.case_dir, container_engine=args.container_engine, num_processors=args.cpus, verbose=args.verbose)
 
     # Handle --no-llm logic: explicitly disable by unsetting env var
     if args.no_llm and "GEMINI_API_KEY" in os.environ:
@@ -200,7 +201,8 @@ def main():
             skip_cfd=args.skip_cfd,
             iteration=i,
             reuse_mesh=args.reuse_mesh,
-            output_prefix=output_prefix
+            output_prefix=output_prefix,
+            verbose=args.verbose
         )
 
         print(f"Result metrics: {metrics}")

--- a/optimizer/simulation_runner.py
+++ b/optimizer/simulation_runner.py
@@ -6,7 +6,7 @@ import shutil
 from utils import Timer, get_container_memory_gb
 from parameter_validator import validate_parameters
 
-def run_simulation(scad_driver, foam_driver, params, output_stl_name="corkscrew_fluid.stl", dry_run=False, skip_cfd=False, iteration=0, reuse_mesh=False, output_prefix=None):
+def run_simulation(scad_driver, foam_driver, params, output_stl_name="corkscrew_fluid.stl", dry_run=False, skip_cfd=False, iteration=0, reuse_mesh=False, output_prefix=None, verbose=False):
     """
     Executes the full simulation pipeline:
     1. Generate Fluid Geometry (STL)
@@ -157,8 +157,8 @@ def run_simulation(scad_driver, foam_driver, params, output_stl_name="corkscrew_
                     min_required_cells = block_volume / (min_res_cell_size ** 3)
 
                     if min_required_cells > MAX_CELLS:
-                        print(f"Warning: Minimum resolution requires ~{min_required_cells:.0f} cells, which exceeds memory limit {MAX_CELLS}. Ignoring memory limit to preserve geometry.")
-                        MAX_CELLS = int(min_required_cells)
+                        print(f"WARNING: Geometry requires ~{min_required_cells:.0f} cells for accuracy, but memory limit is {MAX_CELLS}. Resolution will be reduced to fit available RAM. Results may be inaccurate.")
+                        # Do not override MAX_CELLS. Let the subsequent logic resize the mesh.
 
                 if estimated_cells > MAX_CELLS:
                     new_size = (block_volume / MAX_CELLS) ** (1/3)


### PR DESCRIPTION
This PR improves the visibility of OpenFOAM errors and the robustness of the simulation runner on resource-constrained environments.

1.  **Verbose Logging**: A new `--verbose` / `-v` flag in `optimizer/main.py` allows users to see the last 30 lines of the OpenFOAM log file immediately upon command failure. This helps diagnose issues like OOM or floating point exceptions without manually opening log files.
2.  **Robust Memory Handling**: The `simulation_runner.py` previously ignored the calculated memory limit if the geometry required a higher resolution. This often led to crashes on 8GB machines. The logic has been changed to respect the `MAX_CELLS` limit strictly. If the geometry requires more cells than available RAM permits, the runner now issues a warning and reduces the mesh resolution (increases cell size) to prevent a crash, ensuring the optimization loop continues even if accuracy is compromised.

---
*PR created automatically by Jules for task [4866822205509052816](https://jules.google.com/task/4866822205509052816) started by @LokiMetaSmith*