### PR TITLE
Fix Path Separator Mismatch for OpenFOAM on Windows

### DIFF
--- a/optimizer/simulation_runner.py
+++ b/optimizer/simulation_runner.py
@@ -234,7 +234,7 @@ def run_simulation(scad_driver, foam_driver, params, output_stl_name="corkscrew_
         if not reuse_mesh:
             with Timer("Meshing"):
                 # Pass bin config to create bin patches
-                success = foam_driver.run_meshing(log_file=mesh_log, bin_config=bin_config)
+                success = foam_driver.run_meshing(log_file=mesh_log, bin_config=bin_config, stl_filename=output_stl_name)
         else:
             print("[Reuse Mesh] Skipping meshing pipeline.")
             success = True


### PR DESCRIPTION
Fixes a Path Separator Mismatch error on Windows where backslashes in STL paths caused `surfaceMeshConvert` to fail inside the Linux container.

- `optimizer/foam_driver.py`: Added `scale_mesh` with forced forward slashes; updated `run_meshing` to use it.
- `optimizer/simulation_runner.py`: Updated to pass `output_stl_name` to `run_meshing`.

---
*PR created automatically by Jules for task [10130515995879429356](https://jules.google.com/task/10130515995879429356) started by @LokiMetaSmith*