### PR TITLE
Fix meshing failure on Windows by scaling STL in Python

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -1020,11 +1020,7 @@ cloudFunctions
         Runs the meshing pipeline.
         bin_config: {'num_bins': int, 'total_length': float (mm)}
         """
-        # Step 0: Scale STL (Fix for "Scale of the Giants")
-        # We assume the STL is already in constant/triSurface/
-        if not self.scale_mesh(stl_filename, scale_factor=0.001, log_file=log_file):
-             print("Error: Failed to scale mesh.")
-             return False
+        # STL is assumed to be already scaled to meters by simulation_runner.
 
         # Generate patch creation configs
         self._generate_topoSetDict(bin_config)


### PR DESCRIPTION
Replaces `surfaceMeshConvert` execution in Podman with `trimesh` scaling in Python. This resolves exit code 1 errors caused by volume mount permission/path issues on Windows during the meshing phase. Updates simulation runner to handle scaled bounds correctly.

---
*PR created automatically by Jules for task [14324595228966414381](https://jules.google.com/task/14324595228966414381) started by @LokiMetaSmith*