### PR TITLE
Fix OpenFOAM v2406 wallDist error

### DIFF
--- a/corkscrewFilter/system/fvSchemes
+++ b/corkscrewFilter/system/fvSchemes
@@ -50,9 +50,9 @@ snGradSchemes
     default         corrected;
 }
 
-wallDist
-{
-    method meshWave;
-}
+// wallDist
+// {
+//     method meshWave;
+// }
 
 // ************************************************************************* //


### PR DESCRIPTION
The `wallDist` dictionary in `corkscrewFilter/system/fvSchemes` was causing a "FOAM FATAL IO ERROR: Entry 'method' not found" during `simpleFoam` execution. In OpenFOAM v2406, `wallDist` configuration in `fvSchemes` is optional and usually defaults to `meshWave`. This commit comments out the problematic entry to allow the solver to use the robust default behavior.

---
*PR created automatically by Jules for task [3798241318226228532](https://jules.google.com/task/3798241318226228532) started by @LokiMetaSmith*