### PR TITLE
Fix OpenFOAM v2406 crash by removing unsupported patchPostProcessing

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -965,14 +965,7 @@ subModels
 
 cloudFunctions
 {{
-    patchPostProcessing1
-    {{
-        type            patchPostProcessing;
-        maxStoredParcels 20;
-        patches         ( {patch_list_str} );
-        writeControl    writeTime;
-        writeInterval   1;
-    }}
+    // patchPostProcessing removed due to incompatibility with OpenFOAM v2406
 }}
 
 // ************************************************************************* //


### PR DESCRIPTION
Removed the `patchPostProcessing1` block from `optimizer/foam_driver.py`'s `_generate_kinematicCloudProperties` method.
This function object type is not supported in the OpenFOAM v2406 release used by the container, causing a crash.
Verified that existing tests pass and that the configuration is generated correctly without the offending block.
The metrics collection code already has fallback logic for missing files, so the rest of the pipeline remains functional.

---
*PR created automatically by Jules for task [5766408587983887851](https://jules.google.com/task/5766408587983887851) started by @LokiMetaSmith*