### PR TITLE
Add CLI region support and fix worker crash

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,3 +20,4 @@ This file tracks planned enhancements and future work for the Thirsty Corkscrew 
 - [x] **Versioning Strategy:** Implement a hashing or UUID system to link specific job queues/results to the git commit hash of the codebase at the time of execution. This ensures reproducibility.
 - [x] **Agent "Campaign" Mode:** Update the `LLMAgent` to support generating batch "campaigns" (multiple parameter sets) into the queue, rather than single-step iterations.
 - [x] **Synchronization Workflow:** Create scripts/logic to handle the `pull` -> `claim` -> `run` -> `push` lifecycle, allowing a team to collaborate on the optimization surface asynchronously.
+- [x] **CLI Region Support:** Updated `generate_campaign.py` to allow direct job generation for specific parameter regions (e.g., `--param key=min:max`) without requiring LLM assistance.

--- a/optimizer/worker.py
+++ b/optimizer/worker.py
@@ -109,15 +109,15 @@ def main():
 
         # 5. Run Simulation
         params = target_job["parameters"]
-        output_stl = f"job_{job_id}.stl" # Use unique STL name to avoid collisions if sharing folder?
-        # Actually foam_driver.case_dir is local, so collision only matters if running parallel on same machine.
-        # But for cleanliness let's use standard name.
+        output_prefix = os.path.join("exports", f"job_{job_id}")
 
         try:
-            metrics, png_paths = run_simulation(
+            # Unpack all 5 return values
+            metrics, png_paths, solid_stl, fluid_stl, vtk_zip = run_simulation(
                 scad, foam, params,
                 output_stl_name="corkscrew_fluid.stl", # Standard name for Foam
-                dry_run=args.dry_run
+                dry_run=args.dry_run,
+                output_prefix=output_prefix
             )
 
             # Check for critical failures in metrics


### PR DESCRIPTION
Implemented CLI support for generating optimization jobs within specific parameter regions using `generate_campaign.py`. This allows users to manually specify search spaces or fixed parameters without relying on the LLM agent.

Also fixed a critical bug in `optimizer/worker.py` where the `run_simulation` function call was expecting 2 return values but receiving 5, causing the worker to crash. The worker now correctly handles all return values and uses the job ID to organize output artifacts.

---
*PR created automatically by Jules for task [11923407359897617019](https://jules.google.com/task/11923407359897617019) started by @LokiMetaSmith*