### PR TITLE
Fix OpenFOAM v2406 wallDist Fatal IO Error

### DIFF
--- a/corkscrewFilter/system/fvSchemes
+++ b/corkscrewFilter/system/fvSchemes
@@ -50,4 +50,9 @@ snGradSchemes
     default         corrected;
 }
 
+wallDist
+{
+    method          meshWave;
+}
+
 // ************************************************************************* //


### PR DESCRIPTION
Added `wallDist` dictionary with `method meshWave;` to `corkscrewFilter/system/fvSchemes` to resolve a fatal IO error in OpenFOAM v2406.

---
*PR created automatically by Jules for task [4943843271855041437](https://jules.google.com/task/4943843271855041437) started by @LokiMetaSmith*