### PR TITLE
Fix OpenFOAM v2406 patchInjection error by using massTotal and parcelsPerSecond

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -746,10 +746,10 @@ patches
             type            patchInjection;
             patch           inlet;
             parcelBasisType mass;
-            massFlowRate    {mass_flow_rate:.6e};
+            massTotal       {mass_flow_rate:.6e};
             duration        1;
             SOI             0;
-            // parcelsPerSecond and nParticle removed for mass basis robustness
+            parcelsPerSecond 5000;
             flowRateProfile constant 1;
             U0              (0 0 5);
             sizeDistribution


### PR DESCRIPTION
The user reported a `FOAM FATAL IO ERROR: Entry 'massTotal' not found` during the particle tracking phase of the optimization loop. This error occurs in `icoUncoupledKinematicParcelFoam` (OpenFOAM v2406) when using `patchInjection` with `parcelBasisType mass`.

I investigated `optimizer/foam_driver.py` and found that `massFlowRate` was being used, and `parcelsPerSecond` was commented out.

I modified `optimizer/foam_driver.py` to:
1.  Use `massTotal` instead of `massFlowRate`. Since the injection duration is 1.0s, the values are numerically identical.
2.  Re-introduce `parcelsPerSecond 5000` to ensure the solver knows how many parcels to inject per second, which is standard practice for mass-based injection in OpenFOAM.

I verified the fix by creating a temporary unit test `optimizer/test_foam_driver_injection.py` that initialized `FoamDriver` and checked the generated `kinematicCloudProperties` file for the correct entries. The test passed.

---
*PR created automatically by Jules for task [18280695121987042921](https://jules.google.com/task/18280695121987042921) started by @LokiMetaSmith*