### PR TITLE
Fix SIGFPE in particle tracking by removing uncoupled sourceTerms

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -768,6 +768,10 @@ patches
             {
                 type stick;
             }
+            walls
+            {
+                type rebound;
+            }
             outlet
             {
                 type escape;
@@ -843,14 +847,6 @@ solution
     integrationSchemes
     {{
         U               Euler;
-    }}
-
-    sourceTerms
-    {{
-        schemes
-        {{
-            U               explicit 1;
-        }}
     }}
 }}
 

--- a/test/test_foam_driver_cloud.py
+++ b/test/test_foam_driver_cloud.py
@@ -78,18 +78,24 @@ class TestFoamDriverCloud(unittest.TestCase):
 
             # Assertions for Mass Basis Fix
             self.assertIn("parcelBasisType mass;", content)
-            self.assertIn("massFlowRate", content)
+            self.assertIn("massTotal", content)
             self.assertIn("rho0", content)
 
-            # Verify massFlowRate is calculated and formatted (e.g. scientific notation)
+            # Verify massTotal is calculated and formatted (e.g. scientific notation)
             # We check for a number.
             import re
-            self.assertTrue(re.search(r"massFlowRate\s+[\d\.e\-\+]+;", content), "massFlowRate value not found")
+            self.assertTrue(re.search(r"massTotal\s+[\d\.e\-\+]+;", content), "massTotal value not found")
 
             # Verify problematic entries are removed (ensure they are not active keys)
             # Use regex to avoid matching comments (e.g. "// nParticle removed")
             self.assertFalse(re.search(r"^\s*nParticle\s+", content, re.MULTILINE), "nParticle parameter found active")
-            self.assertFalse(re.search(r"^\s*parcelsPerSecond\s+", content, re.MULTILINE), "parcelsPerSecond parameter found active")
+
+            # Verify SIGFPE Fix: Ensure sourceTerms is removed
+            self.assertNotIn("sourceTerms", content)
+
+            # Verify Walls Patch is added
+            self.assertIn("walls", content)
+            self.assertIn("type rebound;", content)
 
     @patch('optimizer.foam_driver.run_command_with_spinner')
     @patch('optimizer.foam_driver.FoamDriver._print_log_tail')


### PR DESCRIPTION
Removes the `sourceTerms` dictionary from `kinematicCloudProperties` when using `icoUncoupledKinematicParcelFoam` in uncoupled mode (`coupled false`). This prevents a SIGFPE crash caused by the solver attempting to access invalid field data (e.g., U matrix coefficients) for source term calculation on a frozen field. Also adds a `walls` patch interaction with `type rebound` to ensure robust handling of all boundary faces. Updated `test/test_foam_driver_cloud.py` to reflect these changes and correct mass basis parameter assertions.

---
*PR created automatically by Jules for task [5898782964451264415](https://jules.google.com/task/5898782964451264415) started by @LokiMetaSmith*