### PR TITLE
Fix OpenFOAM command quoting in FoamDriver

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -6,6 +6,7 @@ import re
 import math
 import sys
 import contextlib
+import shlex
 import numpy as np
 from utils import run_command_with_spinner
 
@@ -160,7 +161,7 @@ class FoamDriver:
             "-w", container_workdir,
         ] + uid_gid_args + [
             self.docker_image,
-            "/bin/bash", "-lc", f"cd {container_workdir} && " + " ".join(cmd)
+            "/bin/bash", "-lc", f"cd {container_workdir} && " + shlex.join(cmd)
         ]
 
         return container_cmd


### PR DESCRIPTION
Fixed an issue where OpenFOAM commands with parentheses (like `minMax(U)`) caused a syntax error when running inside a container. The fix involves using `shlex.join` to properly quote arguments in the generated shell command string. verified with a test script.

---
*PR created automatically by Jules for task [7710149780127749966](https://jules.google.com/task/7710149780127749966) started by @LokiMetaSmith*