### PR TITLE
Geometric Validation and Explicit CFD Boundaries

### DIFF
--- a/config.scad
+++ b/config.scad
@@ -10,7 +10,7 @@
 
 // --- 1. Model Selection ---
 // This variable controls which component is rendered.
-part_options = ["modular_filter_assembly", "hex_array_filter", "single_cell_filter", "hose_adapter_cap", "flat_end_screw", "filter_holder", "custom_coupling"];
+part_options = ["modular_filter_assembly", "hex_array_filter", "single_cell_filter", "hose_adapter_cap", "flat_end_screw", "filter_holder", "custom_coupling", "inlet_cap", "outlet_cap", "cfd_wall"];
 // We use is_undef to prevent overwriting if this file is included after variables are set.
 default_part_to_generate = part_options[0];
 
@@ -135,6 +135,7 @@ slit_axial_length_mm = 1.5;      // The height (Z-axis) of the slit cut for Cork
 slit_chamfer_height = 0.5;       // The height of the chamfer on the leading edge of the slit knife.
 
 // --- Tolerances & Fit ---
-tolerance_tube_fit = 0.2;        // Clearance between the spacers and the inner wall of the main tube.
+_tolerance_tube_fit_base = 0.2;        // Clearance between the spacers and the inner wall of the main tube.
+tolerance_tube_fit = GENERATE_CFD_VOLUME ? 0 : _tolerance_tube_fit_base; // Force 0 tolerance for CFD to seal bins
 tolerance_socket_fit = 0.4;      // Clearance for sockets and recesses, like for the inlet flange.
 tolerance_channel = 0.1;         // Extra clearance for the helical void to prevent binding during assembly.

--- a/config.scad
+++ b/config.scad
@@ -54,6 +54,7 @@ tube_wall_mm = 1;                // The wall thickness of the tube. Used to calc
 tube_length_override = 0;        // Custom length for the visualized tube (0 = auto/match component).
 insert_length_mm = 50 ;      // The total length of the filter insert from end to end.
 num_bins = 3;                    // The number of separate helical screw segments in the modular assembly.
+cfd_shape = "circle";            // Shape of the fluid domain for CFD ["circle", "square", "hex"].
 
 // --- Helical Screw Parameters ---
 number_of_complete_revolutions = 1; // How many full 360-degree turns the screw makes over its total length.

--- a/corkscrew.scad
+++ b/corkscrew.scad
@@ -62,11 +62,14 @@ module GenerateSelectedPart() {
             tube_wall = tube_wall_mm
         );
     } else if (target_part == "inlet_cap") {
-        InletCap(tube_od_mm - 2 * tube_wall_mm, insert_length_mm);
+        shape = is_undef(cfd_shape) ? "circle" : cfd_shape;
+        InletCap(tube_od_mm - 2 * tube_wall_mm, insert_length_mm, shape);
     } else if (target_part == "outlet_cap") {
-        OutletCap(tube_od_mm - 2 * tube_wall_mm, insert_length_mm);
+        shape = is_undef(cfd_shape) ? "circle" : cfd_shape;
+        OutletCap(tube_od_mm - 2 * tube_wall_mm, insert_length_mm, shape);
     } else if (target_part == "cfd_wall") {
-        CFDWall(tube_od_mm - 2 * tube_wall_mm, insert_length_mm);
+        shape = is_undef(cfd_shape) ? "circle" : cfd_shape;
+        CFDWall(tube_od_mm - 2 * tube_wall_mm, insert_length_mm, shape);
     } else {
         echo("Error: `part_to_generate` variable is not set to a valid option.");
         echo("Please check `config.scad` and choose from the `part_options` list.");

--- a/corkscrew.scad
+++ b/corkscrew.scad
@@ -15,6 +15,7 @@ include <modules/inlets.scad>
 include <modules/assemblies.scad>
 include <modules/custom_couplings.scad> // Added for legacy support
 include <modules/filter_holder.scad>
+include <modules/cfd_helpers.scad>
 
 // =============================================================================
 // --- 2. Main Logic ---
@@ -60,6 +61,12 @@ module GenerateSelectedPart() {
             oring_cs = oring_cross_section_mm,
             tube_wall = tube_wall_mm
         );
+    } else if (target_part == "inlet_cap") {
+        InletCap(tube_od_mm - 2 * tube_wall_mm, insert_length_mm);
+    } else if (target_part == "outlet_cap") {
+        OutletCap(tube_od_mm - 2 * tube_wall_mm, insert_length_mm);
+    } else if (target_part == "cfd_wall") {
+        CFDWall(tube_od_mm - 2 * tube_wall_mm, insert_length_mm);
     } else {
         echo("Error: `part_to_generate` variable is not set to a valid option.");
         echo("Please check `config.scad` and choose from the `part_options` list.");

--- a/modules/cfd_helpers.scad
+++ b/modules/cfd_helpers.scad
@@ -1,76 +1,100 @@
+include <BOSL2/std.scad>
+
 // =============================================================================
-// --- CFD Helper Modules ---
+// --- CFD Helper Modules (BOSL2 Refactor) ---
 // =============================================================================
 // This file contains modules for generating explicit CFD boundaries (inlet, outlet, walls)
-// as separate STL files. Supports cylindrical, square, and hexagonal profiles.
+// as separate STL files. Supports cylindrical, square, and hexagonal profiles using
+// BOSL2 attachments for robust alignment.
 
 /**
- * Module: CapShape
- * Description: Generates the 2D profile for the cap.
+ * Module: CFD_Reference_Shape
+ * Description: Generates the reference fluid domain shape used for attaching caps.
+ * This object is usually used as a phantom (%) parent.
+ * Arguments:
+ * d: Characteristic dimension (Diameter for circle/hex, Side for square).
+ * h: Length of the fluid domain.
+ * shape: "circle", "square", "hex"
+ * anchor: BOSL2 anchor (default CENTER)
  */
-module CapShape(d, shape="circle") {
+module CFD_Reference_Shape(d, h, shape="circle", anchor=CENTER, spin=0, orient=UP) {
     if (shape == "square") {
-        square([d, d], center=true);
+        // cuboid takes size=[x,y,z]
+        cuboid(size=[d, d, h], anchor=anchor, spin=spin, orient=orient);
     } else if (shape == "hex") {
-        // cylinder with $fn=6 creates a hexagon.
-        // d is usually corner-to-corner diameter if using cylinder(d=...)
-        circle(d=d, $fn=6);
+        // cyl with $fn=6 is a hex prism
+        // circum = true means d is the diameter of the circumcircle (corner-to-corner)
+        // This matches standard cylinder(d=...) behavior for $fn=6 in OpenSCAD?
+        // OpenSCAD cylinder(d=...) fits vertices to the circle.
+        // BOSL2 cyl(d=...) does the same.
+        cyl(d=d, h=h, $fn=6, anchor=anchor, spin=spin, orient=orient);
     } else {
-        circle(d=d);
+        // circle
+        cyl(d=d, h=h, anchor=anchor, spin=spin, orient=orient);
+    }
+}
+
+/**
+ * Module: CapGeometry
+ * Description: The actual geometry of the cap (thin plate).
+ */
+module CapGeometry(d, shape="circle", thickness=0.5, anchor=CENTER, spin=0, orient=UP) {
+    if (shape == "square") {
+        cuboid(size=[d, d, thickness], anchor=anchor, spin=spin, orient=orient);
+    } else if (shape == "hex") {
+        cyl(d=d, h=thickness, $fn=6, anchor=anchor, spin=spin, orient=orient);
+    } else {
+        cyl(d=d, h=thickness, anchor=anchor, spin=spin, orient=orient);
     }
 }
 
 /**
  * Module: InletCap
- * Description: Generates a flat disk/plate representing the inlet patch.
- * Arguments:
- * d: Characteristic dimension (Diameter for circle/hex, Side for square).
- * h: Length of the fluid domain.
- * shape: "circle", "square", "hex"
+ * Description: Generates the inlet patch attached to the BOTTOM of the fluid domain.
  */
 module InletCap(d, h, shape="circle") {
-    // Positioned at the bottom (Z-) face
-    translate([0, 0, -h/2])
-        linear_extrude(height=0.5, center=true)
-            CapShape(d, shape);
+    // Create the phantom fluid volume and attach the cap to its bottom
+    %CFD_Reference_Shape(d, h, shape=shape)
+        attach(BOTTOM)
+            CapGeometry(d, shape=shape, thickness=0.5, anchor=CENTER); // anchor=CENTER aligns center of cap with bottom of fluid
+            // Wait, attach(BOTTOM) puts the child at the bottom face.
+            // If child anchor is CENTER, the child's center is at the parent's bottom face.
+            // This means half the cap is inside, half outside.
+            // Ideally, the patch surface is the interface.
+            // If the fluid is -H/2 to H/2. Bottom is -H/2.
+            // We want the cap face to be at -H/2.
+            // If we use anchor=TOP for the cap, its TOP face touches the parent's BOTTOM face.
+            // That places the cap strictly OUTSIDE (below) the fluid.
+            // If we use anchor=BOTTOM, it's inside.
+            // For CFD patches, we usually want the face itself.
+            // SnappyHexMesh works best if the STL surface is exactly on the boundary.
+            // A 0.5mm thick plate centered at the boundary is fine.
+            // So anchor=CENTER is robust.
 }
 
 /**
  * Module: OutletCap
- * Description: Generates a flat disk/plate representing the outlet patch.
- * Arguments:
- * d: Characteristic dimension.
- * h: Length of the fluid domain.
- * shape: "circle", "square", "hex"
+ * Description: Generates the outlet patch attached to the TOP of the fluid domain.
  */
 module OutletCap(d, h, shape="circle") {
-    // Positioned at the top (Z+) face
-    translate([0, 0, h/2])
-        linear_extrude(height=0.5, center=true)
-            CapShape(d, shape);
+    %CFD_Reference_Shape(d, h, shape=shape)
+        attach(TOP)
+            CapGeometry(d, shape=shape, thickness=0.5, anchor=CENTER);
 }
 
 /**
  * Module: CFDWall
- * Description: Generates a shell representing the outer wall of the fluid domain.
- * Arguments:
- * d: Characteristic dimension (Inner size).
- * h: Length of the fluid domain.
- * shape: "circle", "square", "hex"
+ * Description: Generates the outer wall shell.
  */
 module CFDWall(d, h, shape="circle") {
     wall_thickness = 1.0;
 
-    // Outer dimension depends on shape to maintain wall thickness
-    // For circle: d + 2*t
-    // For square: d + 2*t (side)
-    // For hex: d is diam (corner-to-corner).
+    // Create a larger shell and subtract the inner reference shape
+    // We can use diff() on the outer shape
 
     difference() {
-        linear_extrude(height=h, center=true)
-            CapShape(d + 2*wall_thickness, shape);
-
-        linear_extrude(height=h + 1, center=true)
-            CapShape(d, shape);
+        CFD_Reference_Shape(d + 2*wall_thickness, h, shape=shape);
+        // Inner void (slightly taller to ensure clean cut)
+        CFD_Reference_Shape(d, h + 1, shape=shape);
     }
 }

--- a/modules/cfd_helpers.scad
+++ b/modules/cfd_helpers.scad
@@ -1,0 +1,48 @@
+// =============================================================================
+// --- CFD Helper Modules ---
+// =============================================================================
+// This file contains modules for generating explicit CFD boundaries (inlet, outlet, walls)
+// as separate STL files.
+
+/**
+ * Module: InletCap
+ * Description: Generates a flat disk representing the inlet patch.
+ * Arguments:
+ * d: Diameter of the fluid domain (tube ID).
+ * h: Length of the fluid domain.
+ */
+module InletCap(d, h) {
+    // Positioned at the bottom (Z-) face
+    // Thickness 0.5mm to ensure robust intersection with boundary faces
+    translate([0, 0, -h/2])
+        cylinder(d = d, h = 0.5, center = true);
+}
+
+/**
+ * Module: OutletCap
+ * Description: Generates a flat disk representing the outlet patch.
+ * Arguments:
+ * d: Diameter of the fluid domain (tube ID).
+ * h: Length of the fluid domain.
+ */
+module OutletCap(d, h) {
+    // Positioned at the top (Z+) face
+    translate([0, 0, h/2])
+        cylinder(d = d, h = 0.5, center = true);
+}
+
+/**
+ * Module: CFDWall
+ * Description: Generates a cylindrical shell representing the outer wall of the fluid domain.
+ * This can be used to explicitly patch the tube walls.
+ * Arguments:
+ * d: Diameter of the fluid domain (tube ID).
+ * h: Length of the fluid domain.
+ */
+module CFDWall(d, h) {
+    wall_thickness = 1.0;
+    difference() {
+        cylinder(d = d + 2 * wall_thickness, h = h, center = true);
+        cylinder(d = d, h = h + 1, center = true);
+    }
+}

--- a/modules/cfd_helpers.scad
+++ b/modules/cfd_helpers.scad
@@ -2,47 +2,75 @@
 // --- CFD Helper Modules ---
 // =============================================================================
 // This file contains modules for generating explicit CFD boundaries (inlet, outlet, walls)
-// as separate STL files.
+// as separate STL files. Supports cylindrical, square, and hexagonal profiles.
+
+/**
+ * Module: CapShape
+ * Description: Generates the 2D profile for the cap.
+ */
+module CapShape(d, shape="circle") {
+    if (shape == "square") {
+        square([d, d], center=true);
+    } else if (shape == "hex") {
+        // cylinder with $fn=6 creates a hexagon.
+        // d is usually corner-to-corner diameter if using cylinder(d=...)
+        circle(d=d, $fn=6);
+    } else {
+        circle(d=d);
+    }
+}
 
 /**
  * Module: InletCap
- * Description: Generates a flat disk representing the inlet patch.
+ * Description: Generates a flat disk/plate representing the inlet patch.
  * Arguments:
- * d: Diameter of the fluid domain (tube ID).
+ * d: Characteristic dimension (Diameter for circle/hex, Side for square).
  * h: Length of the fluid domain.
+ * shape: "circle", "square", "hex"
  */
-module InletCap(d, h) {
+module InletCap(d, h, shape="circle") {
     // Positioned at the bottom (Z-) face
-    // Thickness 0.5mm to ensure robust intersection with boundary faces
     translate([0, 0, -h/2])
-        cylinder(d = d, h = 0.5, center = true);
+        linear_extrude(height=0.5, center=true)
+            CapShape(d, shape);
 }
 
 /**
  * Module: OutletCap
- * Description: Generates a flat disk representing the outlet patch.
+ * Description: Generates a flat disk/plate representing the outlet patch.
  * Arguments:
- * d: Diameter of the fluid domain (tube ID).
+ * d: Characteristic dimension.
  * h: Length of the fluid domain.
+ * shape: "circle", "square", "hex"
  */
-module OutletCap(d, h) {
+module OutletCap(d, h, shape="circle") {
     // Positioned at the top (Z+) face
     translate([0, 0, h/2])
-        cylinder(d = d, h = 0.5, center = true);
+        linear_extrude(height=0.5, center=true)
+            CapShape(d, shape);
 }
 
 /**
  * Module: CFDWall
- * Description: Generates a cylindrical shell representing the outer wall of the fluid domain.
- * This can be used to explicitly patch the tube walls.
+ * Description: Generates a shell representing the outer wall of the fluid domain.
  * Arguments:
- * d: Diameter of the fluid domain (tube ID).
+ * d: Characteristic dimension (Inner size).
  * h: Length of the fluid domain.
+ * shape: "circle", "square", "hex"
  */
-module CFDWall(d, h) {
+module CFDWall(d, h, shape="circle") {
     wall_thickness = 1.0;
+
+    // Outer dimension depends on shape to maintain wall thickness
+    // For circle: d + 2*t
+    // For square: d + 2*t (side)
+    // For hex: d is diam (corner-to-corner).
+
     difference() {
-        cylinder(d = d + 2 * wall_thickness, h = h, center = true);
-        cylinder(d = d, h = h + 1, center = true);
+        linear_extrude(height=h, center=true)
+            CapShape(d + 2*wall_thickness, shape);
+
+        linear_extrude(height=h + 1, center=true)
+            CapShape(d, shape);
     }
 }

--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -538,11 +538,10 @@ functions
 
         return True
 
-    def _generate_topoSetDict(self, bin_config=None):
+    def _generate_topoSetDict(self, bin_config=None, skip_io=False):
         """
         Generates system/topoSetDict.
-        If bin_config is provided ({'num_bins': int, 'total_length': float}), it generates
-        bin-specific face sets.
+        skip_io: if True, skips generation of inlet/outlet face sets (assumes snappy did it).
         """
         bin_actions = ""
         if bin_config and bin_config.get("num_bins", 1) > 1:
@@ -582,6 +581,45 @@ functions
     }}
 """
 
+        io_actions = ""
+        if not skip_io:
+            io_actions = """
+    // 2. Select Inlet Faces (Bottom, Normal 0 0 -1)
+    {
+        name    inletFaces;
+        type    faceSet;
+        action  new;
+        source  normalToFace;
+        normal  (0 0 -1);
+        cos     0.8; // Tolerance (allow some deviation)
+    }
+    // Intersect with corkscrew boundary faces
+    {
+        name    inletFaces;
+        type    faceSet;
+        action  subset;
+        source  faceToFace;
+        set     corkscrewFaces;
+    }
+
+    // 3. Select Outlet Faces (Top, Normal 0 0 1)
+    {
+        name    outletFaces;
+        type    faceSet;
+        action  new;
+        source  normalToFace;
+        normal  (0 0 1);
+        cos     0.8;
+    }
+    {
+        name    outletFaces;
+        type    faceSet;
+        action  subset;
+        source  faceToFace;
+        set     corkscrewFaces;
+    }
+"""
+
         content = f"""/*--------------------------------*- C++ -*----------------------------------*\\
 | =========                 |                                                 |
 | \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
@@ -609,42 +647,7 @@ actions
         source  patchToFace;
         patch   corkscrew;
     }}
-
-    // 2. Select Inlet Faces (Bottom, Normal 0 0 -1)
-    {{
-        name    inletFaces;
-        type    faceSet;
-        action  new;
-        source  normalToFace;
-        normal  (0 0 -1);
-        cos     0.8; // Tolerance (allow some deviation)
-    }}
-    // Intersect with corkscrew boundary faces
-    {{
-        name    inletFaces;
-        type    faceSet;
-        action  subset;
-        source  faceToFace;
-        set     corkscrewFaces;
-    }}
-
-    // 3. Select Outlet Faces (Top, Normal 0 0 1)
-    {{
-        name    outletFaces;
-        type    faceSet;
-        action  new;
-        source  normalToFace;
-        normal  (0 0 1);
-        cos     0.8;
-    }}
-    {{
-        name    outletFaces;
-        type    faceSet;
-        action  subset;
-        source  faceToFace;
-        set     corkscrewFaces;
-    }}
-
+    {io_actions}
     // 4. Bin Split Actions
     {bin_actions}
 );
@@ -654,7 +657,7 @@ actions
         with open(os.path.join(self.case_dir, "system", "topoSetDict"), 'w') as f:
             f.write(content)
 
-    def _generate_createPatchDict(self, bin_config=None):
+    def _generate_createPatchDict(self, bin_config=None, skip_io=False):
         """
         Generates system/createPatchDict.
         """
@@ -673,6 +676,30 @@ actions
         constructFrom set;
         set bin_{i+1}_faces;
     }}"""
+
+        io_patches = ""
+        if not skip_io:
+            io_patches = """
+    {
+        name inlet;
+        patchInfo
+        {{
+            type patch;
+            inGroups (inletGroup);
+        }}
+        constructFrom set;
+        set inletFaces;
+    }
+    {
+        name outlet;
+        patchInfo
+        {{
+            type patch;
+            inGroups (outletGroup);
+        }}
+        constructFrom set;
+        set outletFaces;
+    }"""
 
         content = f"""/*--------------------------------*- C++ -*----------------------------------*\\
 | =========                 |                                                 |
@@ -694,26 +721,7 @@ pointSync false;
 
 patches
 (
-    {{
-        name inlet;
-        patchInfo
-        {{
-            type patch;
-            inGroups (inletGroup);
-        }}
-        constructFrom set;
-        set inletFaces;
-    }}
-    {{
-        name outlet;
-        patchInfo
-        {{
-            type patch;
-            inGroups (outletGroup);
-        }}
-        constructFrom set;
-        set outletFaces;
-    }}
+    {io_patches}
     {bin_patches}
 );
 
@@ -954,24 +962,117 @@ cloudFunctions
                     f.write(f"\nError renaming scaled mesh: {e}\n")
             return False
 
-    def run_meshing(self, log_file=None, bin_config=None, stl_filename="corkscrew_fluid.stl"):
+    def _replace_block(self, content, block_name, new_inner_content):
+        """Helper to replace a block like geometry { ... } in a dictionary string."""
+        start_idx = content.find(block_name)
+        if start_idx == -1: return content
+
+        open_brace = content.find("{", start_idx)
+        if open_brace == -1: return content
+
+        cnt = 1
+        pos = open_brace + 1
+        while cnt > 0 and pos < len(content):
+            if content[pos] == '{': cnt += 1
+            elif content[pos] == '}': cnt -= 1
+            pos += 1
+
+        if cnt == 0:
+            before = content[:open_brace+1]
+            after = content[pos-1:]
+            return before + "\n" + new_inner_content + "\n    " + after
+        return content
+
+    def _generate_snappyHexMeshDict(self, stl_assets):
+        """
+        Updates system/snappyHexMeshDict to include all assets as geometry/patches.
+        stl_assets: {'fluid': 'f.stl', 'inlet': 'i.stl', ...}
+        """
+        geometry_str = ""
+        refinement_str = ""
+
+        # Ensure we have at least fluid
+        if not stl_assets: return
+
+        for key, filename in stl_assets.items():
+            # Determine snappy patch name
+            # fluid -> corkscrew
+            # wall -> corkscrew (merge)
+            # inlet -> inlet
+            # outlet -> outlet
+
+            patch_name = "corkscrew"
+            if key == "inlet": patch_name = "inlet"
+            elif key == "outlet": patch_name = "outlet"
+            elif key == "wall": patch_name = "corkscrew"
+
+            geometry_str += f"""
+    {filename}
+    {{
+        type triSurfaceMesh;
+        name {patch_name};
+    }}
+"""
+            # Refinement Surface
+            level = "(1 1)"
+
+            patch_info = ""
+            if key in ["inlet", "outlet"]:
+                patch_info = f"""
+            patchInfo
+            {{
+                type patch;
+                inGroups ({patch_name}Group);
+            }}"""
+
+            refinement_str += f"""
+        {patch_name}
+        {{
+            level {level};{patch_info}
+        }}
+"""
+
+        template_path = os.path.join(self.case_dir, "system", "snappyHexMeshDict.template")
+        if os.path.exists(template_path):
+            with open(template_path, 'r') as f: content = f.read()
+        else:
+            print("Error: snappyHexMeshDict.template missing")
+            return
+
+        content = self._replace_block(content, "geometry", geometry_str)
+        content = self._replace_block(content, "refinementSurfaces", refinement_str)
+
+        with open(os.path.join(self.case_dir, "system", "snappyHexMeshDict"), 'w') as f:
+            f.write(content)
+
+    def run_meshing(self, log_file=None, bin_config=None, stl_assets=None):
         """
         Runs the meshing pipeline.
-        bin_config: {'num_bins': int, 'total_length': float (mm)}
+        stl_assets: dict of filenames {'fluid': '...', 'inlet': '...', ...}
         """
-        # STL is assumed to be already scaled to meters by simulation_runner.
+        # 1. Update snappyHexMeshDict if assets provided
+        using_assets = False
+        if stl_assets and isinstance(stl_assets, dict):
+            self._generate_snappyHexMeshDict(stl_assets)
+            using_assets = True
 
-        # Generate patch creation configs
-        self._generate_topoSetDict(bin_config)
-        self._generate_createPatchDict(bin_config)
+        # 2. Generate patch creation configs
+        # Pass using_assets flag to conditionally skip inlet/outlet creation
+        self._generate_topoSetDict(bin_config, skip_io=using_assets)
+        self._generate_createPatchDict(bin_config, skip_io=using_assets)
 
         # Ensure we capture output
         # Step 1: Base Mesh
         if not self.run_command(["blockMesh"], log_file=log_file, description="Meshing (blockMesh)"): return False
+
+        # For surfaceFeatureExtract, if using assets, we might need to update that dict too?
+        # Typically checks 'corkscrew_fluid.stl'. If fluid asset has different name, might fail.
+        # But simulation_runner handles fluid name.
         if not self.run_command(["surfaceFeatureExtract"], log_file=log_file, description="Meshing (surfaceFeatureExtract)"): return False
+
         if not self.run_command(["snappyHexMesh", "-overwrite"], log_file=log_file, description="Meshing (snappyHexMesh)"): return False
 
-        # Step 2: Create Patches
+        # Step 2: Create Patches (Bin faces only if using_assets)
         if not self.run_command(["topoSet"], log_file=log_file, description="Meshing (topoSet)"): return False
         if not self.run_command(["createPatch", "-overwrite"], log_file=log_file, description="Meshing (createPatch)"): return False
 

--- a/optimizer/scad_driver.py
+++ b/optimizer/scad_driver.py
@@ -464,6 +464,66 @@ class ScadDriver:
             print(f"Error calculating internal point: {e}")
             return None
 
+    def generate_cfd_assets(self, params, output_dir, log_file=None, params_file=None):
+        """
+        Generates all STLs required for CFD: fluid, inlet, outlet, wall.
+
+        Args:
+            params (dict): Parameters for the model.
+            output_dir (str): Directory to save the STLs.
+            log_file (str): Path to log file.
+            params_file (str): Path to a SCAD parameter file to use as config.
+
+        Returns:
+            dict: Paths to the generated STLs {'fluid', 'inlet', 'outlet', 'wall'}, or None if failed.
+        """
+        # Ensure output directory exists
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+
+        # 1. Main Fluid Volume
+        fluid_params = params.copy()
+        fluid_params["GENERATE_CFD_VOLUME"] = "true"
+        # Ensure correct part is selected (default to modular if not set)
+        if "part_to_generate" not in fluid_params:
+            fluid_params["part_to_generate"] = "modular_filter_assembly"
+
+        fluid_path = os.path.join(output_dir, "corkscrew_fluid.stl")
+        if not self.generate_stl(fluid_params, fluid_path, log_file, params_file):
+            print("Failed to generate fluid volume.")
+            return None
+
+        # 2. Inlet Cap
+        inlet_params = fluid_params.copy()
+        inlet_params["part_to_generate"] = "inlet_cap"
+        inlet_path = os.path.join(output_dir, "inlet.stl")
+        if not self.generate_stl(inlet_params, inlet_path, log_file, params_file):
+            print("Failed to generate inlet cap.")
+            return None
+
+        # 3. Outlet Cap
+        outlet_params = fluid_params.copy()
+        outlet_params["part_to_generate"] = "outlet_cap"
+        outlet_path = os.path.join(output_dir, "outlet.stl")
+        if not self.generate_stl(outlet_params, outlet_path, log_file, params_file):
+            print("Failed to generate outlet cap.")
+            return None
+
+        # 4. Wall
+        wall_params = fluid_params.copy()
+        wall_params["part_to_generate"] = "cfd_wall"
+        wall_path = os.path.join(output_dir, "wall.stl")
+        if not self.generate_stl(wall_params, wall_path, log_file, params_file):
+            print("Failed to generate CFD wall.")
+            return None
+
+        return {
+            "fluid": fluid_path,
+            "inlet": inlet_path,
+            "outlet": outlet_path,
+            "wall": wall_path
+        }
+
 if __name__ == "__main__":
     # Test stub
     driver = ScadDriver("corkscrew.scad")

--- a/optimizer/simulation_runner.py
+++ b/optimizer/simulation_runner.py
@@ -5,6 +5,7 @@ import numpy as np
 import shutil
 from utils import Timer, get_container_memory_gb
 from parameter_validator import validate_parameters
+from validator import Validator
 
 def run_simulation(scad_driver, foam_driver, params, output_stl_name="corkscrew_fluid.stl", dry_run=False, skip_cfd=False, iteration=0, reuse_mesh=False, output_prefix=None, verbose=False, params_file=None):
     """
@@ -56,34 +57,77 @@ def run_simulation(scad_driver, foam_driver, params, output_stl_name="corkscrew_
     else:
         print("Skipping parameter validation due to external params file.")
 
-    # 1. Generate Geometry (Fluid Volume for CFD)
-    stl_path = os.path.join(foam_driver.case_dir, "constant", "triSurface", output_stl_name)
-    os.makedirs(os.path.dirname(stl_path), exist_ok=True)
+    # 1. Generate Geometry (Fluid Volume + CFD Assets)
+    tri_surface_dir = os.path.join(foam_driver.case_dir, "constant", "triSurface")
+    os.makedirs(tri_surface_dir, exist_ok=True)
+
+    # Use specified output name for fluid, others are fixed
+    fluid_stl_path = os.path.join(tri_surface_dir, output_stl_name)
 
     SCALE_FACTOR = 0.001 # mm to meters
+    cfd_assets = {} # Dictionary of absolute paths
 
     if not dry_run:
         if not reuse_mesh:
             with Timer("Geometry Generation"):
-                success = scad_driver.generate_stl(params, stl_path, log_file=geom_log, params_file=params_file)
+                # Use generate_cfd_assets to create all required STLs
+                # Note: generate_cfd_assets returns paths to 'corkscrew_fluid.stl', 'inlet.stl', etc.
+                # We should rename the fluid one if output_stl_name is different, but for now we trust generate_cfd_assets defaults or move it.
+                assets = scad_driver.generate_cfd_assets(params, tri_surface_dir, log_file=geom_log, params_file=params_file)
 
-            if success:
-                # Scale STL to meters immediately to avoid container issues
-                print(f"Scaling STL to meters...")
-                if not scad_driver.scale_mesh(stl_path, SCALE_FACTOR):
-                    print("Failed to scale mesh.")
-                    return {"error": "mesh_scaling_failed"}, [], None, None, None
+            if assets:
+                cfd_assets = assets
+                # If the generated fluid name doesn't match requested output_stl_name, rename/copy?
+                # generate_cfd_assets produces 'corkscrew_fluid.stl' fixed name.
+                # If output_stl_name is different, we handle it.
+                generated_fluid = cfd_assets["fluid"]
+                if os.path.basename(generated_fluid) != output_stl_name:
+                    shutil.move(generated_fluid, fluid_stl_path)
+                    cfd_assets["fluid"] = fluid_stl_path
+
+                # 1.1 Validation (in mm, before scaling)
+                print("Validating Geometry...")
+                validator = Validator(verbose=verbose)
+                val_res = validator.validate_assembly(
+                    cfd_assets["fluid"],
+                    cfd_assets["inlet"],
+                    cfd_assets["outlet"],
+                    cfd_assets["wall"],
+                    tolerance=1.0 # 1mm tolerance
+                )
+
+                if not val_res["valid"]:
+                    print(f"Geometry Validation Failed: {val_res['messages']}")
+                    return {"error": "geometry_validation_failed", "details": val_res['messages']}, [], None, None, None
+
+                print("Geometry Validation Passed.")
+
+                # 1.2 Scaling (to meters)
+                print(f"Scaling STLs to meters...")
+                for key, path in cfd_assets.items():
+                    if not scad_driver.scale_mesh(path, SCALE_FACTOR):
+                        print(f"Failed to scale mesh: {key}")
+                        return {"error": "mesh_scaling_failed"}, [], None, None, None
             else:
                 print(f"Geometry generation failed. Check {geom_log} for details.")
                 return {"error": "geometry_generation_failed"}, [], None, None, None
         else:
             print("[Reuse Mesh] Skipping geometry generation.")
+            # Populate cfd_assets assuming files exist
+            cfd_assets = {
+                "fluid": fluid_stl_path,
+                "inlet": os.path.join(tri_surface_dir, "inlet.stl"),
+                "outlet": os.path.join(tri_surface_dir, "outlet.stl"),
+                "wall": os.path.join(tri_surface_dir, "wall.stl")
+            }
     else:
-        print(f"[Dry Run] Generated STL at {stl_path}")
-        if not os.path.exists(stl_path):
-            with open(stl_path, 'w') as f: f.write("solid dryrun\nendsolid dryrun")
+        print(f"[Dry Run] Generated STL at {fluid_stl_path}")
+        if not os.path.exists(fluid_stl_path):
+            with open(fluid_stl_path, 'w') as f: f.write("solid dryrun\nendsolid dryrun")
 
     # 2. Update Mesh Config
+    stl_path = fluid_stl_path # For bounds check
+
     if not dry_run and not skip_cfd:
         # Early check for environment
         if not foam_driver.has_tools:
@@ -243,8 +287,10 @@ def run_simulation(scad_driver, foam_driver, params, output_stl_name="corkscrew_
 
         if not reuse_mesh:
             with Timer("Meshing"):
-                # Pass bin config to create bin patches
-                success = foam_driver.run_meshing(log_file=mesh_log, bin_config=bin_config, stl_filename=output_stl_name)
+                # Pass bin config AND assets
+                # We pass just filenames as they are in triSurface
+                asset_filenames = {k: os.path.basename(v) for k, v in cfd_assets.items()}
+                success = foam_driver.run_meshing(log_file=mesh_log, bin_config=bin_config, stl_assets=asset_filenames)
         else:
             print("[Reuse Mesh] Skipping meshing pipeline.")
             success = True

--- a/optimizer/validator.py
+++ b/optimizer/validator.py
@@ -1,0 +1,145 @@
+import trimesh
+import numpy as np
+import os
+import warnings
+
+class Validator:
+    def __init__(self, verbose=False):
+        self.verbose = verbose
+
+    def _load_mesh(self, stl_path):
+        """Safely loads a mesh, handling Scenes."""
+        try:
+            with warnings.catch_warnings():
+                warnings.filterwarnings('ignore', category=RuntimeWarning, module='trimesh') # Suppress loading warnings
+                mesh = trimesh.load(stl_path)
+
+            if isinstance(mesh, trimesh.Scene):
+                if len(mesh.geometry) == 0:
+                    return None
+                mesh = trimesh.util.concatenate(tuple(mesh.geometry.values()))
+            return mesh
+        except Exception as e:
+            if self.verbose:
+                print(f"Error loading {stl_path}: {e}")
+            return None
+
+    def validate_mesh(self, stl_path, check_watertight=True, check_volume=True):
+        """
+        Validates a single STL file.
+        Returns (valid: bool, messages: list)
+        """
+        if not os.path.exists(stl_path):
+            return False, [f"File not found: {stl_path}"]
+
+        mesh = self._load_mesh(stl_path)
+        if mesh is None:
+             return False, ["Failed to load mesh or empty scene."]
+
+        messages = []
+        valid = True
+
+        if mesh.is_empty:
+            return False, ["Mesh is empty."]
+
+        if check_watertight and not mesh.is_watertight:
+            # Caps and Fluid volume should be watertight in this workflow
+            messages.append("Mesh is not watertight.")
+            valid = False
+
+        if check_volume and mesh.volume <= 0:
+            messages.append(f"Mesh has non-positive volume: {mesh.volume:.6f}")
+            valid = False
+
+        if len(mesh.faces) == 0:
+             messages.append("Mesh has 0 faces.")
+             valid = False
+
+        return valid, messages
+
+    def validate_assembly(self, fluid_path, inlet_path, outlet_path, wall_path, tolerance=1.0):
+        """
+        Validates the assembly of CFD components.
+        Checks for existence, validity, and basic alignment.
+        tolerance: max deviation in mesh units (default 1.0)
+        """
+        results = {"valid": True, "messages": []}
+
+        # 1. Validate individual components
+        # Note: Inlet/Outlet caps are small, might have tiny volume, but should be watertight cylinders.
+        components = {
+            "Fluid": fluid_path,
+            "Inlet": inlet_path,
+            "Outlet": outlet_path,
+            "Wall": wall_path
+        }
+
+        meshes = {}
+
+        for name, path in components.items():
+            v, msgs = self.validate_mesh(path, check_watertight=True, check_volume=True)
+            if not v:
+                results["valid"] = False
+                results["messages"].append(f"{name} validation failed: {'; '.join(msgs)}")
+            else:
+                if self.verbose:
+                    results["messages"].append(f"{name} passed individual checks.")
+                # Load for next step
+                if results["valid"]: # Only load if valid so far
+                    meshes[name] = self._load_mesh(path)
+
+        if not results["valid"]:
+            return results
+
+        # 2. Geometric Relations
+        try:
+            fluid = meshes["Fluid"]
+            inlet = meshes["Inlet"]
+            outlet = meshes["Outlet"]
+            wall = meshes["Wall"]
+
+            f_min, f_max = fluid.bounds
+            i_min, i_max = inlet.bounds
+            o_min, o_max = outlet.bounds
+            w_min, w_max = wall.bounds
+
+            tol = tolerance
+
+            # Check A: Inlet near Fluid Min Z
+            # Inlet cap (center) should be close to Fluid min Z
+            i_center_z = (i_min[2] + i_max[2]) / 2
+            if abs(i_center_z - f_min[2]) > tol and abs(i_center_z - f_max[2]) > tol:
+                # Note: Inlet might be at Max Z if coordinate system is flipped, but usually Min Z.
+                # Actually, in ModularFilterAssembly, Z=0 is center. Min Z is bottom.
+                if not (i_max[2] >= f_min[2] - tol and i_min[2] <= f_max[2] + tol):
+                     results["valid"] = False
+                     results["messages"].append(f"Inlet is not vertically aligned with Fluid. Inlet Z: {i_min[2]:.2f}-{i_max[2]:.2f}, Fluid Z: {f_min[2]:.2f}-{f_max[2]:.2f}")
+
+            # Check B: Outlet near Fluid Max Z (or Min Z if swapped)
+            o_center_z = (o_min[2] + o_max[2]) / 2
+            # Verify outlet is at opposite end of inlet?
+            # Or just check if it touches the bounding box.
+            if not (o_max[2] >= f_min[2] - tol and o_min[2] <= f_max[2] + tol):
+                 results["valid"] = False
+                 results["messages"].append(f"Outlet is not vertically aligned with Fluid. Outlet Z: {o_min[2]:.2f}-{o_max[2]:.2f}")
+
+            # Check C: Wall encloses Fluid (XY)
+            # Wall bounds should be >= Fluid bounds in XY
+            # Allow small tolerance
+            if (w_min[0] > f_min[0] + tol) or (w_max[0] < f_max[0] - tol) or \
+               (w_min[1] > f_min[1] + tol) or (w_max[1] < f_max[1] - tol):
+                results["messages"].append(f"Warning: Wall XY bounds do not fully enclose Fluid XY bounds. Wall might be too small or misaligned.")
+                # Don't fail hard on this, purely warning
+
+        except Exception as e:
+            results["valid"] = False
+            results["messages"].append(f"Assembly validation exception: {e}")
+
+        return results
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        v = Validator(verbose=True)
+        res = v.validate_mesh(sys.argv[1])
+        print(res)

--- a/test_cfd_gen.scad
+++ b/test_cfd_gen.scad
@@ -1,0 +1,10 @@
+include <modules/cfd_helpers.scad>
+
+// Test Inlet
+translate([50, 0, 0]) InletCap(30, 50, "circle");
+
+// Test Outlet
+translate([-50, 0, 0]) OutletCap(30, 50, "square");
+
+// Test Wall
+translate([0, 50, 0]) CFDWall(30, 50, "hex");


### PR DESCRIPTION
This PR introduces a robust geometric validation step and explicit boundary generation for the OpenFOAM CFD pipeline.

Key changes:
1.  **Validation:** A new `Validator` class uses `trimesh` to verify that generated STLs are watertight, have positive volume, and that the inlet/outlet caps align correctly with the fluid domain. This prevents expensive simulations from running on broken geometry.
2.  **Explicit Geometry:** The `generate_cfd_assets` method now produces separate STLs for the fluid volume, inlet cap, outlet cap, and outer wall. These are generated via new OpenSCAD modules (`modules/cfd_helpers.scad`).
3.  **Sealed Bins:** `config.scad` was modified to force zero tolerance between spacers and the tube when generating the CFD volume. This ensures that particle collection bins are geometrically sealed, preventing artificial leakage in the simulation.
4.  **Robust Meshing:** `FoamDriver` was updated to dynamically generate `snappyHexMeshDict`, injecting the explicit boundary STLs as named patches. This replaces the previous `topoSet` heuristic (selecting faces by normal vector), which was prone to errors on complex geometries.

These changes directly address the issue of "open bins" and provide a mechanism to flag failing models early.

---
*PR created automatically by Jules for task [3573414886287711591](https://jules.google.com/task/3573414886287711591) started by @LokiMetaSmith*