### PR TITLE
Fix JobManager parameter type handling for lists vs tuples

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,3 +21,4 @@ This file tracks planned enhancements and future work for the Thirsty Corkscrew 
 - [x] **Agent "Campaign" Mode:** Update the `LLMAgent` to support generating batch "campaigns" (multiple parameter sets) into the queue, rather than single-step iterations.
 - [x] **Synchronization Workflow:** Create scripts/logic to handle the `pull` -> `claim` -> `run` -> `push` lifecycle, allowing a team to collaborate on the optimization surface asynchronously.
 - [x] **CLI Region Support:** Updated `generate_campaign.py` to allow direct job generation for specific parameter regions (e.g., `--param key=min:max`) without requiring LLM assistance.
+- [x] **Bug Fix:** Fixed parameter type handling in `JobManager` to correctly distinguish between ranges (tuples) and discrete choices (lists).

--- a/optimizer/job_manager.py
+++ b/optimizer/job_manager.py
@@ -97,7 +97,7 @@ class JobManager:
         for _ in range(num_samples):
             params = {}
             for key, val in param_ranges.items():
-                if isinstance(val, (tuple, list)) and len(val) == 2 and isinstance(val[0], (int, float)):
+                if isinstance(val, tuple) and len(val) == 2 and isinstance(val[0], (int, float)):
                     # Random sample
                     if isinstance(val[0], int) and isinstance(val[1], int):
                         params[key] = random.randint(val[0], val[1])


### PR DESCRIPTION
This PR fixes a bug in `JobManager.generate_jobs_from_region` where lists of length 2 (e.g., `[10, 20]`) were incorrectly treated as continuous ranges (e.g., `(10, 20)`) because `isinstance(val, (tuple, list))` matched both.

The fix restricts the range check to `tuple` only, ensuring that `list` values fall through to the discrete choice logic.

This allows users to specify discrete choices like `--param num_bins=1,2` (which produces `[1, 2]`) and have the system randomly choose between 1 and 2, rather than picking a random float/int between them.

---
*PR created automatically by Jules for task [14018096518829147974](https://jules.google.com/task/14018096518829147974) started by @LokiMetaSmith*