### PR TITLE
Implement particleCollector metrics aggregation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,8 +28,8 @@ This file tracks planned enhancements and future work for the Thirsty Corkscrew 
 * [ ] **Switch Integration Scheme:** Change the particle tracking integration scheme from `Euler` to `analytical` in `kinematicCloudProperties` to resolve the SIGFPE math explosion caused by explicit integration overshooting drag equilibrium on fine particles.
 
 ## Metric Extraction & Data Handling
-* [ ] **Implement `particleCollector`:** Inject `particleCollector` into the `cloudFunctions` dictionary to capture discrete particle fate data for individual trapping bins.
-* [ ] **Aggregate Patch Data:** Update `foam_driver.get_metrics()` to parse the `particleCollector` CSV/OBJ outputs. Aggregate the raw hit counts into LLM-friendly summary statistics (e.g., capture efficiency per bin).
+- [x] **Implement `particleCollector`:** Inject `particleCollector` into the `cloudFunctions` dictionary to capture discrete particle fate data for individual trapping bins.
+- [x] **Aggregate Patch Data:** Update `foam_driver.get_metrics()` to parse the `particleCollector` CSV/OBJ outputs. Aggregate the raw hit counts into LLM-friendly summary statistics (e.g., capture efficiency per bin).
 * [ ] **Ensure Face Flux (Phi):** Run `postProcess -func writePhi` automatically when preparing the transient `0` directory from steady-state results to ensure velocity interpolation works for all sub-models.
 
 ## Optimization Loop & Architecture

--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -1413,6 +1413,7 @@ boundaryField
             'delta_p': None,
             'residuals': None,
             'capture_by_bin': {},
+            'efficiency_by_bin': {},
             'injected_by_model': {}
         }
 
@@ -1578,6 +1579,18 @@ boundaryField
                                                      pass
                          except Exception as e:
                              print(f"Error parsing patchPostProcessing: {e}")
+
+        # Calculate Efficiency Per Bin (Percent)
+        # Relies on total injected particles (sum of all models)
+        total_injected = metrics.get('particles_injected', 0)
+
+        # Ensure capture_by_bin exists
+        if 'capture_by_bin' in metrics:
+            for bin_name, count in metrics['capture_by_bin'].items():
+                if total_injected > 0:
+                    metrics['efficiency_by_bin'][bin_name] = (count / total_injected) * 100.0
+                else:
+                    metrics['efficiency_by_bin'][bin_name] = 0.0
 
         return metrics
 

--- a/test/test_foam_metrics.py
+++ b/test/test_foam_metrics.py
@@ -1,0 +1,65 @@
+import unittest
+import os
+import sys
+import shutil
+import tempfile
+import numpy as np
+
+# Ensure we can import from optimizer and its dependencies
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'optimizer')))
+
+from optimizer.foam_driver import FoamDriver
+
+class TestFoamMetrics(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.driver = FoamDriver(self.test_dir)
+        # Create dummy log file
+        with open(self.driver.log_file, 'w') as f:
+            f.write("Dummy Log\n")
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_parse_particle_collector(self):
+        # Setup directory structure for particleCollector
+        pp_dir = os.path.join(self.test_dir, "postProcessing", "lagrangian", "cloud", "particleCollector1", "0")
+        os.makedirs(pp_dir)
+
+        dat_file = os.path.join(pp_dir, "particleCollector1.dat")
+
+        # Write dummy data
+        # Header: # Time bin_1 bin_2 inlet outlet
+        # Data: 10.0 50 30 10 500
+        with open(dat_file, 'w') as f:
+            f.write("# Time\tbin_1\tbin_2\tinlet\toutlet\n")
+            f.write("1.0\t10\t5\t2\t100\n")
+            f.write("10.0\t50\t30\t10\t500\n")
+
+        # Mock log file for total injection
+        # "Injector model_10um: injected 1000 parcels"
+        with open(self.driver.log_file, 'w') as f:
+            f.write("Starting simulation...\n")
+            f.write("Injector model_10um: injected 1000 parcels\n")
+            f.write("Injector model_20um: injected 1000 parcels\n")
+            f.write("End\n")
+
+        metrics = self.driver.get_metrics()
+
+        print("Metrics:", metrics)
+
+        self.assertIn("capture_by_bin", metrics)
+        self.assertEqual(metrics["capture_by_bin"]["bin_1"], 50)
+        self.assertEqual(metrics["capture_by_bin"]["bin_2"], 30)
+        self.assertEqual(metrics["particles_injected"], 2000)
+
+        # Check if efficiencies are calculated
+        self.assertIn("efficiency_by_bin", metrics)
+        # 50 / 2000 = 2.5%
+        self.assertAlmostEqual(metrics["efficiency_by_bin"]["bin_1"], 2.5)
+        # 30 / 2000 = 1.5%
+        self.assertAlmostEqual(metrics["efficiency_by_bin"]["bin_2"], 1.5)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR implements the aggregation of particle capture data from OpenFOAM's `particleCollector` function object. 

Changes:
1.  **Metric Calculation**: Updated `optimizer/foam_driver.py`'s `get_metrics` method to calculate `efficiency_by_bin` (percentage) by normalizing `capture_by_bin` counts against the total `particles_injected`. This provides LLM-friendly summary statistics for optimization.
2.  **Testing**: Added `test/test_foam_metrics.py`, a unit test that mocks `particleCollector` output files and logs to verify that the parsing and efficiency calculation logic works correctly.
3.  **Documentation**: Updated `TODO.md` to reflect that `particleCollector` implementation and patch data aggregation are now complete.

The implementation handles cases where no particles are injected (avoiding division by zero) and correctly parses standard `particleCollector` output formats.

---
*PR created automatically by Jules for task [1090013139592226304](https://jules.google.com/task/1090013139592226304) started by @LokiMetaSmith*