### PR TITLE
Fix empty STL export for CFD caps

### DIFF
--- a/modules/cfd_helpers.scad
+++ b/modules/cfd_helpers.scad
@@ -53,23 +53,16 @@ module CapGeometry(d, shape="circle", thickness=0.5, anchor=CENTER, spin=0, orie
  * Description: Generates the inlet patch attached to the BOTTOM of the fluid domain.
  */
 module InletCap(d, h, shape="circle") {
-    // Create the phantom fluid volume and attach the cap to its bottom
-    %CFD_Reference_Shape(d, h, shape=shape)
-        attach(BOTTOM)
-            CapGeometry(d, shape=shape, thickness=0.5, anchor=CENTER); // anchor=CENTER aligns center of cap with bottom of fluid
-            // Wait, attach(BOTTOM) puts the child at the bottom face.
-            // If child anchor is CENTER, the child's center is at the parent's bottom face.
-            // This means half the cap is inside, half outside.
-            // Ideally, the patch surface is the interface.
-            // If the fluid is -H/2 to H/2. Bottom is -H/2.
-            // We want the cap face to be at -H/2.
-            // If we use anchor=TOP for the cap, its TOP face touches the parent's BOTTOM face.
-            // That places the cap strictly OUTSIDE (below) the fluid.
-            // If we use anchor=BOTTOM, it's inside.
-            // For CFD patches, we usually want the face itself.
-            // SnappyHexMesh works best if the STL surface is exactly on the boundary.
-            // A 0.5mm thick plate centered at the boundary is fine.
-            // So anchor=CENTER is robust.
+    // Create the phantom fluid volume for visualization (separate from the exported geometry)
+    // NOTE: We do not wrap CapGeometry in %CFD_Reference_Shape because the % modifier
+    // propagates to children, preventing the cap from being exported in the STL.
+    %CFD_Reference_Shape(d, h, shape=shape);
+
+    // Manually position the cap at the bottom
+    // CFD_Reference_Shape defaults to anchor=CENTER, so BOTTOM is at -h/2.
+    // anchor=CENTER aligns center of cap with bottom of fluid.
+    down(h/2)
+        CapGeometry(d, shape=shape, thickness=0.5, anchor=CENTER);
 }
 
 /**
@@ -77,9 +70,13 @@ module InletCap(d, h, shape="circle") {
  * Description: Generates the outlet patch attached to the TOP of the fluid domain.
  */
 module OutletCap(d, h, shape="circle") {
-    %CFD_Reference_Shape(d, h, shape=shape)
-        attach(TOP)
-            CapGeometry(d, shape=shape, thickness=0.5, anchor=CENTER);
+    // Visualization phantom
+    %CFD_Reference_Shape(d, h, shape=shape);
+
+    // Manually position the cap at the top
+    // CFD_Reference_Shape defaults to anchor=CENTER, so TOP is at h/2.
+    up(h/2)
+        CapGeometry(d, shape=shape, thickness=0.5, anchor=CENTER);
 }
 
 /**

--- a/test/test_cfd_generation.py
+++ b/test/test_cfd_generation.py
@@ -1,0 +1,76 @@
+import unittest
+import os
+import sys
+import tempfile
+import trimesh
+from unittest.mock import patch
+import subprocess
+
+# Ensure we can import from optimizer and its dependencies
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'optimizer')))
+from optimizer.scad_driver import ScadDriver
+
+class TestCFDGeneration(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Ensure we are in the repo root for export.js to work
+        cls.original_cwd = os.getcwd()
+        cls.repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        os.chdir(cls.repo_root)
+        cls.driver = ScadDriver("corkscrew.scad")
+
+    @classmethod
+    def tearDownClass(cls):
+        # Restore original working directory
+        os.chdir(cls.original_cwd)
+
+    def verify_stl(self, stl_path):
+        """Verifies that the STL file exists and is a valid, watertight mesh."""
+        self.assertTrue(os.path.exists(stl_path), f"STL file not found: {stl_path}")
+
+        # Load the mesh using trimesh
+        mesh = trimesh.load(stl_path, file_type='stl')
+        self.assertIsNotNone(mesh, "Failed to load mesh")
+
+        # Handle Scene objects (if multiple bodies)
+        if isinstance(mesh, trimesh.Scene):
+            if len(mesh.geometry) == 0:
+                self.fail("Loaded mesh is an empty scene")
+            mesh = trimesh.util.concatenate(tuple(mesh.geometry.values()))
+
+        self.assertGreater(mesh.volume, 0, "Mesh volume is not positive")
+        # Note: InletCap/OutletCap are single sheets if thickness is small?
+        # But CapGeometry has thickness=0.5. So it should be a volume.
+        self.assertTrue(mesh.is_watertight, "Mesh is not watertight")
+
+    def test_inlet_cap_generation(self):
+        """Test generation of Inlet Cap STL."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = os.path.join(temp_dir, "inlet.stl")
+            params = {
+                "part_to_generate": "inlet_cap",
+                "GENERATE_CFD_VOLUME": True,
+                "high_res_fn": 20 # Low res for speed
+            }
+            print("Generating Inlet Cap...")
+            success = self.driver.generate_stl(params, output_path)
+            self.assertTrue(success, "Inlet Cap generation failed")
+            self.verify_stl(output_path)
+
+    def test_outlet_cap_generation(self):
+        """Test generation of Outlet Cap STL."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = os.path.join(temp_dir, "outlet.stl")
+            params = {
+                "part_to_generate": "outlet_cap",
+                "GENERATE_CFD_VOLUME": True,
+                "high_res_fn": 20
+            }
+            print("Generating Outlet Cap...")
+            success = self.driver.generate_stl(params, output_path)
+            self.assertTrue(success, "Outlet Cap generation failed")
+            self.verify_stl(output_path)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_cfd_generation.py
+++ b/test/test_cfd_generation.py
@@ -30,7 +30,11 @@ class TestCFDGeneration(unittest.TestCase):
         self.assertTrue(os.path.exists(stl_path), f"STL file not found: {stl_path}")
 
         # Load the mesh using trimesh
-        mesh = trimesh.load(stl_path, file_type='stl')
+        try:
+            mesh = trimesh.load(stl_path, file_type='stl')
+        except Exception as e:
+            self.fail(f"Failed to load STL: {e}")
+
         self.assertIsNotNone(mesh, "Failed to load mesh")
 
         # Handle Scene objects (if multiple bodies)
@@ -40,34 +44,60 @@ class TestCFDGeneration(unittest.TestCase):
             mesh = trimesh.util.concatenate(tuple(mesh.geometry.values()))
 
         self.assertGreater(mesh.volume, 0, "Mesh volume is not positive")
-        # Note: InletCap/OutletCap are single sheets if thickness is small?
-        # But CapGeometry has thickness=0.5. So it should be a volume.
         self.assertTrue(mesh.is_watertight, "Mesh is not watertight")
 
-    def test_inlet_cap_generation(self):
-        """Test generation of Inlet Cap STL."""
+    def test_inlet_cap_repro_failure(self):
+        """Test generation of Inlet Cap STL using exact parameters from user report."""
         with tempfile.TemporaryDirectory() as temp_dir:
             output_path = os.path.join(temp_dir, "inlet.stl")
             params = {
                 "part_to_generate": "inlet_cap",
+                "num_bins": 1,
+                "number_of_complete_revolutions": 5,
+                "helix_path_radius_mm": 6.0,
+                "helix_profile_radius_mm": 4.0,
+                "helix_void_profile_radius_mm": 2.5,
+                "helix_profile_scale_ratio": 1.0,
+                "tube_od_mm": 32,
+                "insert_length_mm": 50,
                 "GENERATE_CFD_VOLUME": True,
-                "high_res_fn": 20 # Low res for speed
+                "slit_axial_length_mm": 2.5,
+                "slit_chamfer_height": 0.7,
+                "GENERATE_SLICE": False,
+                "CUT_FOR_VISIBILITY": False,
+                "SHOW_TUBE": False,
+                "high_res_fn": 100
             }
-            print("Generating Inlet Cap...")
+
+            print("Generating Inlet Cap with repro parameters...")
             success = self.driver.generate_stl(params, output_path)
             self.assertTrue(success, "Inlet Cap generation failed")
             self.verify_stl(output_path)
 
-    def test_outlet_cap_generation(self):
-        """Test generation of Outlet Cap STL."""
+    def test_outlet_cap_repro_failure(self):
+        """Test generation of Outlet Cap STL using exact parameters from user report."""
         with tempfile.TemporaryDirectory() as temp_dir:
             output_path = os.path.join(temp_dir, "outlet.stl")
             params = {
                 "part_to_generate": "outlet_cap",
+                "num_bins": 1,
+                "number_of_complete_revolutions": 5,
+                "helix_path_radius_mm": 6.0,
+                "helix_profile_radius_mm": 4.0,
+                "helix_void_profile_radius_mm": 2.5,
+                "helix_profile_scale_ratio": 1.0,
+                "tube_od_mm": 32,
+                "insert_length_mm": 50,
                 "GENERATE_CFD_VOLUME": True,
-                "high_res_fn": 20
+                "slit_axial_length_mm": 2.5,
+                "slit_chamfer_height": 0.7,
+                "GENERATE_SLICE": False,
+                "CUT_FOR_VISIBILITY": False,
+                "SHOW_TUBE": False,
+                "high_res_fn": 100
             }
-            print("Generating Outlet Cap...")
+
+            print("Generating Outlet Cap with repro parameters...")
             success = self.driver.generate_stl(params, output_path)
             self.assertTrue(success, "Outlet Cap generation failed")
             self.verify_stl(output_path)


### PR DESCRIPTION
Fixes an issue where generating `inlet.stl` or `outlet.stl` resulted in an empty file because the geometry was wrapped in a background modifier (`%`).
Modified `modules/cfd_helpers.scad` to separate the exportable geometry from the visualization phantom.
Added regression test `test/test_cfd_generation.py`.

---
*PR created automatically by Jules for task [3328303906475944390](https://jules.google.com/task/3328303906475944390) started by @LokiMetaSmith*