### PR TITLE
Fix watertight geometry validation failures in CFD asset generation

### DIFF
--- a/config.scad
+++ b/config.scad
@@ -137,6 +137,6 @@ slit_chamfer_height = 0.5;       // The height of the chamfer on the leading edg
 
 // --- Tolerances & Fit ---
 _tolerance_tube_fit_base = 0.2;        // Clearance between the spacers and the inner wall of the main tube.
-tolerance_tube_fit = GENERATE_CFD_VOLUME ? 0 : _tolerance_tube_fit_base; // Force 0 tolerance for CFD to seal bins
+tolerance_tube_fit = GENERATE_CFD_VOLUME ? -0.1 : _tolerance_tube_fit_base; // Force negative tolerance (overlap) for CFD to ensure clean cut
 tolerance_socket_fit = 0.4;      // Clearance for sockets and recesses, like for the inlet flange.
 tolerance_channel = 0.1;         // Extra clearance for the helical void to prevent binding during assembly.

--- a/optimizer/parameter_validator.py
+++ b/optimizer/parameter_validator.py
@@ -14,7 +14,7 @@ def validate_parameters(params):
         # Extract parameters with defaults matching config.scad where appropriate
         # Dimensions
         tube_od = float(params.get("tube_od_mm", 32))
-        tube_wall = float(params.get("tube_wall_mm", 1.5))
+        tube_wall = float(params.get("tube_wall_mm", 1.0))
 
         path_r = float(params.get("helix_path_radius_mm", 1.8))
         profile_r = float(params.get("helix_profile_radius_mm", 1.8))

--- a/test/test_cfd_generation.py
+++ b/test/test_cfd_generation.py
@@ -102,5 +102,33 @@ class TestCFDGeneration(unittest.TestCase):
             self.assertTrue(success, "Outlet Cap generation failed")
             self.verify_stl(output_path)
 
+    def test_fluid_volume_watertightness(self):
+        """Test generation of Fluid Volume STL (main CFD body) using exact parameters from user report."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = os.path.join(temp_dir, "corkscrew_fluid.stl")
+            params = {
+                "part_to_generate": "modular_filter_assembly",
+                "num_bins": 1,
+                "number_of_complete_revolutions": 2,
+                "helix_path_radius_mm": 8.0,
+                "helix_profile_radius_mm": 6.0,
+                "helix_void_profile_radius_mm": 4.0,
+                "helix_profile_scale_ratio": 1.0,
+                "tube_od_mm": 32,
+                "insert_length_mm": 50,
+                "GENERATE_CFD_VOLUME": True,
+                "slit_axial_length_mm": 2.0,
+                "slit_chamfer_height": 0.5,
+                "GENERATE_SLICE": False,
+                "CUT_FOR_VISIBILITY": False,
+                "SHOW_TUBE": False,
+                "high_res_fn": 100
+            }
+
+            print("Generating Fluid Volume with repro parameters...")
+            success = self.driver.generate_stl(params, output_path)
+            self.assertTrue(success, "Fluid Volume generation failed")
+            self.verify_stl(output_path)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR addresses the "Mesh is not watertight" errors encountered during the optimization loop.

**Changes:**
1.  **OpenSCAD Tolerance Fix:** In `config.scad`, `tolerance_tube_fit` is now set to `-0.1` when `GENERATE_CFD_VOLUME` is enabled. This forces the subtracted solid parts (spacers) to slightly penetrate the fluid domain boundary, ensuring a clean boolean subtraction and avoiding non-manifold edges caused by coincident faces.
2.  **Validator Consistency:** In `optimizer/parameter_validator.py`, the default `tube_wall_mm` was changed from `1.5` to `1.0`. This aligns the Python-side validation with the OpenSCAD configuration, allowing parameter sets where the helix radius approaches the true inner diameter (e.g., 15mm radius in a 32mm OD / 1mm Wall tube) to pass validation.
3.  **Testing:** Added a new test case `test_fluid_volume_watertightness` to `test/test_cfd_generation.py` which generates the fluid volume using the problematic parameters from the issue report and asserts that the resulting mesh is watertight.

**Verification:**
- Ran `python test/test_cfd_generation.py` and confirmed all tests pass, including the new regression test.
- Verified that `corkscrew_fluid.stl` is generated as a watertight mesh.

---
*PR created automatically by Jules for task [721704057538111958](https://jules.google.com/task/721704057538111958) started by @LokiMetaSmith*