### PR TITLE
Fix OpenFOAM particleCollector crash by adding mandatory parameters

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -922,8 +922,10 @@ cloudFunctions
     particleCollector1
     {{
         type            particleCollector;
-        mode            primitive;
+        mode            patch;
         patches         ( {patch_list_str} );
+        removeCollected false;
+        polygonData     off;
     }}
 }}
 


### PR DESCRIPTION
This PR fixes a crash in the OpenFOAM simulation pipeline caused by missing mandatory parameters in the `particleCollector` function object for OpenFOAM v2406.

Changes:
- Modified `optimizer/foam_driver.py` within `_generate_kinematicCloudProperties`:
    - Updated `particleCollector1` block.
    - Set `mode` to `patch` (was `primitive`).
    - Added `removeCollected false;` (mandatory parameter).
    - Added `polygonData off;` (optimization).

Testing:
- Ran `test/test_foam_metrics.py` to ensure the change does not break metrics parsing (passed).
- Verified the code changes by reading the file.

---
*PR created automatically by Jules for task [15944426681812791353](https://jules.google.com/task/15944426681812791353) started by @LokiMetaSmith*