### PR TITLE
Fix particle collector reset behavior

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -925,6 +925,7 @@ cloudFunctions
         mode            patch;
         patches         ( {patch_list_str} );
         removeCollected false;
+        resetOnWrite    false;
         polygonData     off;
     }}
 }}


### PR DESCRIPTION
Added `resetOnWrite false;` to the `particleCollector1` configuration in `optimizer/foam_driver.py` to enable cumulative particle counting. Validated with a reproduction script.

---
*PR created automatically by Jules for task [8001221851990479362](https://jules.google.com/task/8001221851990479362) started by @LokiMetaSmith*