### PR TITLE
Make boundary layers optional and implement auto-fallback

### DIFF
--- a/corkscrewFilter/system/snappyHexMeshDict.template
+++ b/corkscrewFilter/system/snappyHexMeshDict.template
@@ -19,7 +19,7 @@ mergeTolerance 1e-6;
 
 castellatedMesh true;
 snap            true;
-addLayers       true;
+addLayers       _ADD_LAYERS_FLAG_;
 
 geometry
 {

--- a/optimizer/constraints.py
+++ b/optimizer/constraints.py
@@ -13,4 +13,5 @@ CONSTRAINTS = """
     - Consider increasing number_of_complete_revolutions to increase centrifugal force.
     - Experiment with `slit_axial_length_mm` (range: 1.0 - 3.0) and `slit_chamfer_height` (range: 0.1 - 1.0) to optimize particle rejection at the slit.
     - Ensure `slit_chamfer_height` < `slit_axial_length_mm`.
+    - `add_layers` (boolean): Default true. Enables boundary layer generation in meshing. Can be set to false if meshing fails or to save time, though it reduces simulation accuracy.
 """

--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -992,7 +992,7 @@ cloudFunctions
             return before + "\n" + new_inner_content + "\n    " + after
         return content
 
-    def _generate_snappyHexMeshDict(self, stl_assets):
+    def _generate_snappyHexMeshDict(self, stl_assets, add_layers=True):
         """
         Updates system/snappyHexMeshDict to include all assets as geometry/patches.
         stl_assets: {'fluid': 'f.stl', 'inlet': 'i.stl', ...}
@@ -1048,13 +1048,16 @@ cloudFunctions
             print("Error: snappyHexMeshDict.template missing")
             return
 
+        # Replace addLayers flag
+        content = content.replace("_ADD_LAYERS_FLAG_", "true" if add_layers else "false")
+
         content = self._replace_block(content, "geometry", geometry_str)
         content = self._replace_block(content, "refinementSurfaces", refinement_str)
 
         with open(os.path.join(self.case_dir, "system", "snappyHexMeshDict"), 'w') as f:
             f.write(content)
 
-    def run_meshing(self, log_file=None, bin_config=None, stl_assets=None):
+    def run_meshing(self, log_file=None, bin_config=None, stl_assets=None, add_layers=True):
         """
         Runs the meshing pipeline.
         stl_assets: dict of filenames {'fluid': '...', 'inlet': '...', ...}
@@ -1062,7 +1065,7 @@ cloudFunctions
         # 1. Update snappyHexMeshDict if assets provided
         using_assets = False
         if stl_assets and isinstance(stl_assets, dict):
-            self._generate_snappyHexMeshDict(stl_assets)
+            self._generate_snappyHexMeshDict(stl_assets, add_layers=add_layers)
             using_assets = True
 
         # 2. Generate patch creation configs
@@ -1079,7 +1082,19 @@ cloudFunctions
         # But simulation_runner handles fluid name.
         if not self.run_command(["surfaceFeatureExtract"], log_file=log_file, description="Meshing (surfaceFeatureExtract)"): return False
 
-        if not self.run_command(["snappyHexMesh", "-overwrite"], log_file=log_file, description="Meshing (snappyHexMesh)"): return False
+        if not self.run_command(["snappyHexMesh", "-overwrite"], log_file=log_file, description="Meshing (snappyHexMesh)"):
+            # Fallback Loop
+            if add_layers:
+                print("Warning: Meshing failed with layers enabled. Retrying with layers disabled (Auto-Fallback)...")
+                # Regenerate config with layers=False
+                if using_assets:
+                    self._generate_snappyHexMeshDict(stl_assets, add_layers=False)
+                    if not self.run_command(["snappyHexMesh", "-overwrite"], log_file=log_file, description="Meshing (snappyHexMesh - Fallback)"):
+                        return False
+                else:
+                    return False # Cannot regenerate without assets
+            else:
+                return False
 
         # Step 2: Create Patches (Bin faces only if using_assets)
         if not self.run_command(["topoSet"], log_file=log_file, description="Meshing (topoSet)"): return False

--- a/optimizer/simulation_runner.py
+++ b/optimizer/simulation_runner.py
@@ -290,7 +290,11 @@ def run_simulation(scad_driver, foam_driver, params, output_stl_name="corkscrew_
                 # Pass bin config AND assets
                 # We pass just filenames as they are in triSurface
                 asset_filenames = {k: os.path.basename(v) for k, v in cfd_assets.items()}
-                success = foam_driver.run_meshing(log_file=mesh_log, bin_config=bin_config, stl_assets=asset_filenames)
+
+                # Extract add_layers parameter, default True
+                add_layers = params.get("add_layers", True)
+
+                success = foam_driver.run_meshing(log_file=mesh_log, bin_config=bin_config, stl_assets=asset_filenames, add_layers=add_layers)
         else:
             print("[Reuse Mesh] Skipping meshing pipeline.")
             success = True


### PR DESCRIPTION
- Updated `corkscrewFilter/system/snappyHexMeshDict.template` to use `_ADD_LAYERS_FLAG_`.
- Updated `optimizer/foam_driver.py`:
    - `_generate_snappyHexMeshDict` now accepts `add_layers` argument.
    - `run_meshing` implements a try-catch-retry loop: if `snappyHexMesh` fails with layers, it retries without them.
- Updated `optimizer/simulation_runner.py` to pass `add_layers` from params.
- Updated `optimizer/constraints.py` to document the new parameter.
- Verified with `test/test_add_layers.py`.

---
*PR created automatically by Jules for task [8031676774280110042](https://jules.google.com/task/8031676774280110042) started by @LokiMetaSmith*