### PR TITLE
Fix grammar and LaTeX rendering in TECHNICAL_REPORT.md

### DIFF
--- a/TECHNICAL_REPORT.md
+++ b/TECHNICAL_REPORT.md
@@ -366,9 +366,11 @@ The separation efficiency of a corkscrew filter is critically dependent on $De$.
 In a helical filter, a solid particle is subject to a complex balance of forces that dictates its trajectory. The "clog-free" nature of the device depends on these forces effectively dominating the particle's motion, ensuring it is directed toward the trapping zones rather than remaining entrained in the clean gas stream.
 
 **Stokes Number ($Stk$)**
-The ability of a particle to follow fluid streamlines is dimensionless characterized by the Stokes number:
+The ability of a particle to follow fluid streamlines is characterized by the dimensionless Stokes number:
+
 $$ Stk = \frac{\tau_p U}{D_h} = \frac{\rho_p d_p^2 U}{18 \mu D_h} $$
-Where $\tau_p$ is the particle relaxation time, $d_p$ is particle diameter, and $\rho_p$ is particle density.
+
+Where $\tau_{p}$ is the particle relaxation time, $d_{p}$ is particle diameter, and $\rho_{p}$ is particle density.
 *   $Stk \ll 1$: Particles follow streamlines (no separation).
 *   $Stk > 1$: Particles detach due to inertia (separation).
 


### PR DESCRIPTION
This change addresses a user-reported issue where the Stokes number definition in `TECHNICAL_REPORT.md` contained a grammatical error and rendered incorrectly (white boxes) in some viewers due to LaTeX syntax issues.

Changes:
- **Grammar:** "is dimensionless characterized by" -> "is characterized by the dimensionless".
- **LaTeX Rendering:** Added blank lines around the `$$` equation block. This is a standard Markdown requirement for block math to be interpreted correctly and not as inline text.
- **LaTeX Syntax:** Changed `\tau_p`, `d_p`, `\rho_p` to `\tau_{p}`, `d_{p}`, `\rho_{p}` to be more robust against parser quirks.

---
*PR created automatically by Jules for task [1715625320664351761](https://jules.google.com/task/1715625320664351761) started by @LokiMetaSmith*