### PR TITLE
Robust OpenFOAM Directory Cleanup to Prevent Iteration Cross-Contamination

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -244,8 +244,23 @@ class FoamDriver:
             shutil.rmtree(edge_mesh)
         os.makedirs(edge_mesh, exist_ok=True)
 
-        # Clean previous results
-        self.run_command(["foamListTimes", "-rm"], ignore_error=True)
+        # Clean previous results (numeric time directories and processors)
+        for d in os.listdir(self.case_dir):
+            path = os.path.join(self.case_dir, d)
+            # Use float check to catch scientific notation like 1e-5
+            try:
+                is_numeric = False
+                if d != "0":
+                    float(d)
+                    is_numeric = True
+            except ValueError:
+                is_numeric = False
+
+            if os.path.isdir(path) and is_numeric:
+                shutil.rmtree(path, ignore_errors=True)
+
+        for p_dir in glob.glob(os.path.join(self.case_dir, "processor*")):
+            shutil.rmtree(p_dir, ignore_errors=True)
 
         # Ensure 0 folder
         zero_orig = os.path.join(self.case_dir, "0.orig")


### PR DESCRIPTION
This PR addresses a critical issue where OpenFOAM results from previous optimization iterations were contaminating subsequent runs, leading to solver crashes (e.g., 'Size X is not equal to expected length Y' Fatal IO Error).

The issue was caused by the `foamListTimes -rm` command failing silently when the case directory was in an inconsistent state (e.g., mismatched mesh). This left behind old time directories (like `2000`) that `icoUncoupledKinematicParcelFoam` would mistakenly use as the initial state for the new iteration.

Changes:
- Modified `optimizer/foam_driver.py`:
    - Replaced `self.run_command(["foamListTimes", "-rm"], ...)` with explicit Python logic using `shutil.rmtree`.
    - Implemented a robust check for numeric time directories using `float(d)` to handle scientific notation (e.g., `1e-5`) and integers.
    - Explicitly excludes the `0` directory (initial conditions) from deletion.
    - Explicitly removes `processor*` directories to clean up parallel run artifacts.
- Verified the fix with a reproduction script (`reproduce_cleanup_issue.py`) that simulated the failure mode and confirmed successful cleanup with the new logic.
- Verified existing tests (`test/test_foam_metrics.py`) passed.

---
*PR created automatically by Jules for task [15455054961689396374](https://jules.google.com/task/15455054961689396374) started by @LokiMetaSmith*