### PR TITLE
Fix OpenFOAM v2406 particle tracking compatibility

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -928,17 +928,11 @@ subModels
 
 cloudFunctions
 {{
-    particleCollector1
+    patchPostProcessing1
     {{
-        type            particleCollector;
-        mode            patch;
+        type            patchPostProcessing;
         patches         ( {patch_list_str} );
-        removeCollected false;
-        resetOnWrite    false;
-        log             true;
-        negateParcelsOppositeNormal false;
-        surfaceFormat   vtk;
-        polygonData     off;
+        maxStoredParcels 1000000;
     }}
 }}
 
@@ -1571,14 +1565,14 @@ boundaryField
             # If not found, we leave the dict empty.
 
             # Try to parse `particleCollector` file output if available (replaced patchPostProcessing)
-            # Path: case/postProcessing/lagrangian/cloud/particleCollector1/*/particleCollector1.dat
-            pp_base = os.path.join(self.case_dir, "postProcessing", "lagrangian", "cloud", "particleCollector1")
+            # Path: case/postProcessing/kinematicCloud/patchPostProcessing1/*/patchPostProcessing1.dat
+            pp_base = os.path.join(self.case_dir, "postProcessing", "kinematicCloud", "patchPostProcessing1")
             if os.path.exists(pp_base):
                  # Find latest time
                  time_dirs = glob.glob(os.path.join(pp_base, "*"))
                  if time_dirs:
                      latest_pp_dir = max(time_dirs, key=os.path.getmtime)
-                     dat_file = os.path.join(latest_pp_dir, "particleCollector1.dat")
+                     dat_file = os.path.join(latest_pp_dir, "patchPostProcessing1.dat")
                      if os.path.exists(dat_file):
                          # Format: # Time patch1 patch2 ...
                          # Data: time val1 val2 ...

--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -928,6 +928,19 @@ subModels
 
 cloudFunctions
 {{
+    // particleCollector1
+    // {{
+    //     type            particleCollector;
+    //     mode            patch;
+    //     patches         ( {patch_list_str} );
+    //     removeCollected false;
+    //     resetOnWrite    false;
+    //     log             true;
+    //     negateParcelsOppositeNormal false;
+    //     surfaceFormat   vtk;
+    //     polygonData     off;
+    // }}
+
     patchPostProcessing1
     {{
         type            patchPostProcessing;
@@ -1565,14 +1578,20 @@ boundaryField
             # If not found, we leave the dict empty.
 
             # Try to parse `particleCollector` file output if available (replaced patchPostProcessing)
+            # Path: case/postProcessing/lagrangian/cloud/particleCollector1/*/particleCollector1.dat
+            # pp_base = os.path.join(self.case_dir, "postProcessing", "lagrangian", "cloud", "particleCollector1")
+
             # Path: case/postProcessing/kinematicCloud/patchPostProcessing1/*/patchPostProcessing1.dat
             pp_base = os.path.join(self.case_dir, "postProcessing", "kinematicCloud", "patchPostProcessing1")
+
             if os.path.exists(pp_base):
                  # Find latest time
                  time_dirs = glob.glob(os.path.join(pp_base, "*"))
                  if time_dirs:
                      latest_pp_dir = max(time_dirs, key=os.path.getmtime)
                      dat_file = os.path.join(latest_pp_dir, "patchPostProcessing1.dat")
+                     # dat_file = os.path.join(latest_pp_dir, "particleCollector1.dat")
+
                      if os.path.exists(dat_file):
                          # Format: # Time patch1 patch2 ...
                          # Data: time val1 val2 ...

--- a/test/test_foam_metrics.py
+++ b/test/test_foam_metrics.py
@@ -23,11 +23,12 @@ class TestFoamMetrics(unittest.TestCase):
         shutil.rmtree(self.test_dir)
 
     def test_parse_particle_collector(self):
-        # Setup directory structure for particleCollector
-        pp_dir = os.path.join(self.test_dir, "postProcessing", "lagrangian", "cloud", "particleCollector1", "0")
+        # Setup directory structure for patchPostProcessing
+        # Path: case/postProcessing/kinematicCloud/patchPostProcessing1/*/patchPostProcessing1.dat
+        pp_dir = os.path.join(self.test_dir, "postProcessing", "kinematicCloud", "patchPostProcessing1", "0")
         os.makedirs(pp_dir)
 
-        dat_file = os.path.join(pp_dir, "particleCollector1.dat")
+        dat_file = os.path.join(pp_dir, "patchPostProcessing1.dat")
 
         # Write dummy data
         # Header: # Time bin_1 bin_2 inlet outlet


### PR DESCRIPTION
This change addresses a compatibility issue with OpenFOAM v2406 where the `particleCollector` function object does not support 3D boundary patches. It replaces `particleCollector` with the native `patchPostProcessing` tool, which is the correct method for this version.

Key changes:
1.  **`optimizer/foam_driver.py`**:
    -   Modified `_generate_kinematicCloudProperties` to generate a `patchPostProcessing1` dictionary instead of `particleCollector1`.
    -   Included the required `maxStoredParcels 1000000;` parameter.
    -   Updated `get_metrics` to search for output files in `postProcessing/kinematicCloud/patchPostProcessing1` and parse `patchPostProcessing1.dat`.

2.  **`test/test_foam_metrics.py`**:
    -   Updated the test setup to create mock data in the new expected directory structure (`postProcessing/kinematicCloud/patchPostProcessing1/0`).
    -   Updated the mock filename to `patchPostProcessing1.dat`.

Verified by running `test/test_foam_metrics.py`, which passed successfully.

---
*PR created automatically by Jules for task [14357448935645648409](https://jules.google.com/task/14357448935645648409) started by @LokiMetaSmith*