### PR TITLE
Fix OpenSCAD CGAL WASM Instability and Timeout Constraints

### DIFF
--- a/modules/cutters.scad
+++ b/modules/cutters.scad
@@ -131,7 +131,7 @@ module RampedKnifeShape(h, twist, radius, profile_radius) {
         translate([0, 0, chamfer_h])
         rotate([0, 0, chamfer_twist])
         linear_extrude(height = body_h, twist = body_twist, center = false)
-             polygon(points = [[radius, 0], [radius+w, -w], [radius+w, w]]);
+             polygon(points = [[radius, 0], [radius+w, -w], [radius+w+0.01, 0], [radius+w, w]]);
     }
 }
 

--- a/modules/helpers.scad
+++ b/modules/helpers.scad
@@ -52,6 +52,7 @@ module MultiHelixRamp(h, twist, dia, helices) {
     for (i = [0 : helices - 1]) {
         rotate([0, 0, i * (360 / helices)]) {
             linear_extrude(height = h, twist = twist, center = true, slices = h > 0 ? h * 2 : 1) {
+                translate([0.01, 0.01])
                 polygon(points = [
                     [0, 0],
                     [dia / 2, 0],

--- a/test/regression.js
+++ b/test/regression.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 const CONFIGS_DIR = 'configs';
 const EXPORTS_DIR = 'exports';
-const TIMEOUT_MS = 300000; // 5 minutes per file
+const TIMEOUT_MS = 600000; // 10 minutes per file
 
 function runRegression() {
     console.log("Starting Regression Test Suite...");


### PR DESCRIPTION
1. *Fix Geometry Stability Issues*
   - Modified `modules/helpers.scad` and `modules/cutters.scad` to resolve CGAL precondition violations during rendering in `openscad-wasm`. Added a micro-translation of `0.01` units for `MultiHelixRamp` polygons to avoid origin-touching singular points, and adjusted the internal ramped slit cutter geometry for stability.
2. *Increase timeout in regression.js*
   - Increased the `TIMEOUT_MS` setting in `test/regression.js` to 600,000ms (10 minutes) since some meshes (e.g. `single_cell_filter`, `flat_end_screw`) can hit the 5-minute cap in strict CI environments.
3. *Tests Validated*
   - Re-ran regression export suite and python-side `test_cfd_generation.py` to ensure parts correctly resolve as watertight assemblies.

---
*PR created automatically by Jules for task [2595398398871785732](https://jules.google.com/task/2595398398871785732) started by @LokiMetaSmith*