### PR TITLE
Fix createPatchDict and locationInMesh generation for OpenFOAM v2512

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -504,8 +504,8 @@ functions
             print("Error: snappyHexMeshDict template not found.")
             return
 
-        # Regex to find locationInMesh (x y z);
-        pattern = re.compile(r"locationInMesh\s+\(.*\);")
+        # Regex to find locationInMesh (x y z); (Using DOTALL to catch multi-line formatting)
+        pattern = re.compile(r"locationInMesh\s*\(.*?\);", re.DOTALL)
         if pattern.search(content):
             content = pattern.sub(f"locationInMesh {location};", content)
 
@@ -666,7 +666,7 @@ actions
         with open(os.path.join(self.case_dir, "system", "topoSetDict"), 'w') as f:
             f.write(content)
 
-    def _generate_createPatchDict(self, bin_config=None, skip_io=False):
+    def _generate_createPatchDict(self, bin_config=None):
         """
         Generates system/createPatchDict.
         """
@@ -675,45 +675,23 @@ actions
             num_bins = int(bin_config["num_bins"])
             for i in range(num_bins):
                 bin_patches += f"""
-    name bin_{i+1};
-    dictionary
     {{
-        type patch;
-        inGroups (corkscrew_bins);
-    }}
-    constructFrom set;
-    set bin_{i+1}_faces;
-"""
+        name bin_{i+1};
+        dictionary
+        {{
+            type patch;
+        }}
+        constructFrom set;
+        set bin_{i+1}_faces;
+    }}"""
 
-        io_patches = ""
-        if not skip_io:
-            io_patches = """
-    name inlet;
-    dictionary
-    {
-        type patch;
-        inGroups (inletGroup);
-    }
-    constructFrom set;
-    set inletFaces;
-
-    name outlet;
-    dictionary
-    {
-        type patch;
-        inGroups (outletGroup);
-    }
-    constructFrom set;
-    set outletFaces;
-"""
-
-        content = f"""/*--------------------------------*- C++ -*----------------------------------*\
+        content = f"""/*--------------------------------*- C++ -*----------------------------------*\\
 | =========                 |                                                 |
-| \      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \    /   O peration     | Version:  v2512                                 |
-|   \  /    A nd           | Website:  www.openfoam.com                      |
-|    \/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  v2512                                 |
+|   \\  /    A nd           | Website:  www.openfoam.com                      |
+|    \\/     M anipulation  |                                                 |
+\\*---------------------------------------------------------------------------*/
 FoamFile
 {{
     version     2.0;
@@ -727,7 +705,24 @@ pointSync false;
 
 patches
 (
-    {io_patches}
+    {{
+        name inlet;
+        dictionary
+        {{
+            type patch;
+        }}
+        constructFrom set;
+        set inletFaces;
+    }}
+    {{
+        name outlet;
+        dictionary
+        {{
+            type patch;
+        }}
+        constructFrom set;
+        set outletFaces;
+    }}
     {bin_patches}
 );
 


### PR DESCRIPTION
Fixes "attempt to read beyond EOF" in `createPatch` and "Point is not inside the mesh" in `snappyHexMesh` caused by outdated syntax generation for OpenFOAM v2512.

---
*PR created automatically by Jules for task [5406380803315646310](https://jules.google.com/task/5406380803315646310) started by @LokiMetaSmith*