### PR TITLE
Update particle and fluid friction parameters

### DIFF
--- a/corkscrewFilter/0.orig/nut
+++ b/corkscrewFilter/0.orig/nut
@@ -34,13 +34,17 @@ boundaryField
 
     walls
     {
-        type            nutkWallFunction;
+        type            nutkRoughWallFunction;
+        Ks              uniform 0.0002;  // 0.2mm layer height roughness!
+        Cs              uniform 0.5;     // Standard roughness constant
         value           uniform 0;
     }
 
     corkscrew
     {
-        type            nutkWallFunction;
+        type            nutkRoughWallFunction;
+        Ks              uniform 0.0002;  // 0.2mm layer height roughness!
+        Cs              uniform 0.5;
         value           uniform 0;
     }
 }

--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -795,8 +795,8 @@ patches
             "(.*)"
             {
                 type rebound;
-                e    0.97;
-                mu   0.09;
+                e    0.80;  // Loses 20% of normal energy on bounce
+                mu   0.45;  // High friction for basalt dragging on plastic
             }"""
 
         patch_interactions = common_catch_all + """


### PR DESCRIPTION
This submission updates the CFD simulation parameters to reflect realistic physical properties for 3D-printed filters and abrasive regolith particles. Particle restitution and friction were modified in `foam_driver.py`, and fluid wall functions in `0.orig/nut` were switched to `nutkRoughWallFunction` to account for a 0.2mm layer line height.

---
*PR created automatically by Jules for task [9512956823750757557](https://jules.google.com/task/9512956823750757557) started by @LokiMetaSmith*