### PR TITLE
Fix OpenFOAM C++ pointer crash by freezing nut field

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -913,7 +913,7 @@ subModels
         {injections}
     }}
 
-    dispersionModel gradientDispersionRAS; //stochasticDispersionRAS;
+    dispersionModel stochasticDispersionRAS; //gradientDispersionRAS;
 
     patchInteractionModel localInteraction;
 
@@ -1326,7 +1326,7 @@ boundaryField
                 shutil.copy2(src, dst)
                 
                 # --- AGGRESSIVE LOWER BOUND & BOUNDARY FREEZE ---
-                if field in ["k", "epsilon", "omega"]:
+                if field in ["k", "epsilon", "omega", "nut"]:
                     with open(dst, 'r', encoding='utf-8', errors='ignore') as f:
                         file_content = f.read()
                     


### PR DESCRIPTION
Fixes an issue where evaluating the `nut` field dynamically without wall functions caused a segmentation fault or FPE in OpenFOAM. Freezing `nut` safely decouples the turbulence fields so that uncoupled particle tracking can succeed with `stochasticDispersionRAS`.

---
*PR created automatically by Jules for task [10654209058278969488](https://jules.google.com/task/10654209058278969488) started by @LokiMetaSmith*