### PR TITLE
Fix export.js cryptic error on missing input file

### DIFF
--- a/export.js
+++ b/export.js
@@ -204,6 +204,11 @@ async function main() {
     }
 
     async function renderFile(inputFile, outputFile, params = [], customParamsFile = null) {
+        if (!fs.existsSync(inputFile)) {
+            console.error(`Error: Input file not found: ${inputFile}`);
+            return false;
+        }
+
         console.log(`Rendering ${inputFile} -> ${outputFile}...`);
         if (params.length > 0) {
              console.log(`  Params: ${params.join(' ')}`);
@@ -296,6 +301,8 @@ async function main() {
             vfsInputPath = '/configs/' + path.basename(inputFile);
         } else if (path.dirname(inputFile) === '.') {
             vfsInputPath = '/' + path.basename(inputFile);
+            // Explicitly write the input file to VFS in case it wasn't captured by rootFiles
+            instance.FS.writeFile('/' + path.basename(inputFile), fs.readFileSync(inputFile));
         } else {
             // Arbitrary path, copy specifically
             const base = path.basename(inputFile);


### PR DESCRIPTION
Fixes an issue where `export.js` fails with a cryptic OpenSCAD WASM error when the input file is missing. Added an explicit `fs.existsSync` check to throw a clear error, and explicitly write current-directory files to the VFS.

---
*PR created automatically by Jules for task [6970217153334506978](https://jules.google.com/task/6970217153334506978) started by @LokiMetaSmith*