### PR TITLE
Fix simulationType configuration for laminar runs in foam_driver.py

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -358,9 +358,11 @@ class FoamDriver:
             content = f.read()
 
         if turbulence == "laminar":
+            content = re.sub(r"simulationType\s+.*?;", "simulationType  laminar;", content)
             content = re.sub(r"model\s+.*?;", "model           laminar;", content)
             content = re.sub(r"turbulence\s+.*?;", "turbulence      off;", content)
         else:
+            content = re.sub(r"simulationType\s+.*?;", "simulationType  RAS;", content)
             content = re.sub(r"model\s+.*?;", f"model           {turbulence};", content)
             content = re.sub(r"turbulence\s+.*?;", "turbulence      on;", content)
 

--- a/patch_foam.py
+++ b/patch_foam.py
@@ -1,9 +1,0 @@
-import re
-with open("optimizer/foam_driver.py", "r") as f:
-    code = f.read()
-
-code = code.replace("self._generate_topoSetDict(bin_config, skip_io=using_assets)", "self._generate_topoSetDict(bin_config, skip_io=False)")
-code = code.replace("self._generate_createPatchDict(bin_config, skip_io=using_assets)", "self._generate_createPatchDict(bin_config, skip_io=False)")
-
-with open("optimizer/foam_driver.py", "w") as f:
-    f.write(code)


### PR DESCRIPTION
This patch modifies `optimizer/foam_driver.py`'s `_update_turbulence_properties` method. Previously, when configuring a laminar run, the `model` in `constant/turbulenceProperties` was set to `laminar;` but the overarching `simulationType` was left as `RAS;`. This caused OpenFOAM v2512 to crash because it attempted to load a RAS model named "laminar", which does not exist. The script now correctly uses regex to replace `simulationType` with `laminar;` when the `turbulence` argument is set to "laminar", and reverts it to `RAS;` when running a turbulent model. I verified the change via `pytest` runs and code review.

---
*PR created automatically by Jules for task [8629563389567763925](https://jules.google.com/task/8629563389567763925) started by @LokiMetaSmith*