### PR TITLE
Fix geometry generation for example manifold config

### DIFF
--- a/configs/example_manifold_config.yaml
+++ b/configs/example_manifold_config.yaml
@@ -1,6 +1,7 @@
 project_name: "Parametric_Cyclone_Filter"
 geometry:
   scad_file: "cyclone_filter_manifold.scad"
+  fluid_volume_module: "fluid_volume"
   parameters:
     cyclone_diameter: { type: "float", min: 50.0, max: 200.0, default: 100.0 }
     cylinder_height: { type: "float", min: 50.0, max: 200.0, default: 100.0 }

--- a/optimizer/main.py
+++ b/optimizer/main.py
@@ -75,9 +75,10 @@ def main():
         sys.exit(1)
 
     scad_file = config.get('geometry', {}).get('scad_file', 'corkscrew.scad')
+    fluid_volume_module = config.get('geometry', {}).get('fluid_volume_module', 'modular_filter_assembly')
 
     # Initialize components
-    scad = ScadDriver(scad_file)
+    scad = ScadDriver(scad_file, fluid_volume_module=fluid_volume_module)
     foam = FoamDriver(args.case_dir, config=config, container_engine=args.container_engine, num_processors=args.cpus, verbose=args.verbose)
 
     # Handle --no-llm logic

--- a/optimizer/scad_driver.py
+++ b/optimizer/scad_driver.py
@@ -8,8 +8,9 @@ import tempfile
 from utils import run_command_with_spinner
 
 class ScadDriver:
-    def __init__(self, scad_file_path, force_native=False):
+    def __init__(self, scad_file_path, force_native=False, fluid_volume_module="modular_filter_assembly"):
         self.scad_file_path = scad_file_path
+        self.fluid_volume_module = fluid_volume_module
 
         has_native = shutil.which("openscad") is not None
         has_node = shutil.which("node") is not None
@@ -285,7 +286,7 @@ class ScadDriver:
         vis_params["GENERATE_SLICE"] = False
         # Ensure we are generating the main assembly if not specified
         if "part_to_generate" not in vis_params:
-            vis_params["part_to_generate"] = "modular_filter_assembly"
+            vis_params["part_to_generate"] = self.fluid_volume_module
 
         # Build command (Force use of export.js for --png support)
         param_args = []
@@ -506,7 +507,7 @@ class ScadDriver:
         fluid_params["GENERATE_CFD_VOLUME"] = "true"
         # Ensure correct part is selected (default to modular if not set)
         if "part_to_generate" not in fluid_params:
-            fluid_params["part_to_generate"] = "modular_filter_assembly"
+            fluid_params["part_to_generate"] = self.fluid_volume_module
 
         fluid_path = os.path.join(output_dir, "corkscrew_fluid.stl")
         mesh_anchor_result = self.generate_stl(fluid_params, fluid_path, log_file, params_file)
@@ -516,7 +517,7 @@ class ScadDriver:
 
         # 2. Inlet Cap
         inlet_params = fluid_params.copy()
-        inlet_params["part_to_generate"] = "inlet_cap"
+        inlet_params["part_to_generate"] = "inlet" if self.fluid_volume_module != "modular_filter_assembly" else "inlet_cap"
         inlet_path = os.path.join(output_dir, "inlet.stl")
         if not self.generate_stl(inlet_params, inlet_path, log_file, params_file):
             print("Failed to generate inlet cap.")
@@ -524,7 +525,7 @@ class ScadDriver:
 
         # 3. Outlet Cap
         outlet_params = fluid_params.copy()
-        outlet_params["part_to_generate"] = "outlet_cap"
+        outlet_params["part_to_generate"] = "outlet" if self.fluid_volume_module != "modular_filter_assembly" else "outlet_cap"
         outlet_path = os.path.join(output_dir, "outlet.stl")
         if not self.generate_stl(outlet_params, outlet_path, log_file, params_file):
             print("Failed to generate outlet cap.")

--- a/optimizer/simulation_runner.py
+++ b/optimizer/simulation_runner.py
@@ -239,7 +239,7 @@ def run_simulation(scad_driver, foam_driver, params, output_stl_name="corkscrew_
                         print("Warning: Could not find internal point using ray tracing. Attempting fallback calculation.")
 
                         # 3. Fallback to analytic calculation
-                        part = params.get("part_to_generate", "modular_filter_assembly")
+                        part = params.get("part_to_generate", scad_driver.fluid_volume_module)
                         if part == "modular_filter_assembly":
                             try:
                                 L = float(params.get("insert_length_mm", 50))

--- a/optimizer/worker.py
+++ b/optimizer/worker.py
@@ -68,6 +68,7 @@ def main():
             sys.exit(1)
 
     scad_file = config.get('geometry', {}).get('scad_file', 'corkscrew.scad')
+    fluid_volume_module = config.get('geometry', {}).get('fluid_volume_module', 'modular_filter_assembly')
 
     worker_id = args.id if args.id else get_default_worker_id()
     print(f"Worker started with ID: {worker_id}")
@@ -75,7 +76,7 @@ def main():
     # Initialize components
     store = DataStore()
     manager = JobManager(store)
-    scad = ScadDriver(scad_file)
+    scad = ScadDriver(scad_file, fluid_volume_module=fluid_volume_module)
     foam = FoamDriver(args.case_dir, config=config)
 
     while True:


### PR DESCRIPTION
The example manifold config was failing with an "empty object" OpenSCAD error because the optimization script hardcoded the default `modular_filter_assembly` module name, which did not exist in `cyclone_filter_manifold.scad`.

This PR dynamically reads `fluid_volume_module` from the YAML configuration, allowing the correct module to be invoked. It also correctly infers that if a custom volume module is used, the boundary patch modules should be named `inlet` and `outlet` instead of the defaults (`inlet_cap` and `outlet_cap`), allowing the complete CFD asset generation to succeed for the example manifold case.

---
*PR created automatically by Jules for task [8907511992420010059](https://jules.google.com/task/8907511992420010059) started by @LokiMetaSmith*