### PR TITLE
Fix Podman machine cleanup to include podman-machine-default

### DIFF
--- a/repair_podman.ps1
+++ b/repair_podman.ps1
@@ -83,9 +83,11 @@ if (Get-Command "podman" -ErrorAction SilentlyContinue) {
             }
         }
     } else {
-        Write-Host "Attempting to remove default Podman machine..."
+        Write-Host "Attempting to remove default Podman machines..."
         podman machine stop default 2>$null
         podman machine rm -f default 2>$null
+        podman machine stop podman-machine-default 2>$null
+        podman machine rm -f podman-machine-default 2>$null
     }
 }
 


### PR DESCRIPTION
Modified `repair_podman.ps1` to explicitly stop and remove both `default` and `podman-machine-default` machine instances during the fallback cleanup step. This resolves an issue where re-initializing Podman would fail with `vm "podman-machine-default" already exists on hypervisor` when `podman machine list` could not cleanly retrieve existing machine names.

---
*PR created automatically by Jules for task [5117510908788536578](https://jules.google.com/task/5117510908788536578) started by @LokiMetaSmith*