### PR TITLE
Fix: Dynamically Switch to Laminar Mode on Coarse Memory-Scaled Meshes

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -1683,6 +1683,10 @@ cloudFunctions
                     content = re.sub(r"^\s*Ks\s+.*?$\n?", "", content, flags=re.MULTILINE)
                     content = re.sub(r"^\s*Cs\s+.*?$\n?", "", content, flags=re.MULTILINE)
 
+                if new_wall_func == "zeroGradient":
+                    content = re.sub(r"type\s+zeroGradient;\s*value\s+uniform\s+[\d\.\-e\+]+;", r"type            zeroGradient;", content)
+                    content = re.sub(r"type\s+zeroGradient;\s*value\s+\$internalField;", r"type            zeroGradient;", content)
+
                 with open(field_path, "w") as f:
                     f.write(content)
 

--- a/optimizer/simulation_runner.py
+++ b/optimizer/simulation_runner.py
@@ -330,6 +330,14 @@ def run_simulation(scad_driver, foam_driver, params, output_stl_name="corkscrew_
         if success:
             with Timer("Solver"):
                 _scaled = mesh_scaled_for_memory if 'mesh_scaled_for_memory' in locals() else False
+                if _scaled:
+                    print("Mesh was scaled for memory. Switching turbulence model to 'laminar' for stability.")
+                    turbulence = "laminar"
+                    # Update turbulence properties, fvSchemes, and fvSolution to laminar
+                    foam_driver._update_turbulence_properties(turbulence)
+                    foam_driver._update_fvSchemes(turbulence)
+                    foam_driver._update_fvSolution(turbulence, foam_driver.config.get('cfd_settings', {}))
+
                 success = foam_driver.run_solver(log_file=solver_log, mesh_scaled_for_memory=_scaled)
 
             if success:


### PR DESCRIPTION
Resolves floating-point exceptions that occur during large simulations restricted by small RAM containers. By bypassing heavy turbulent kinetic computations on excessively large scaled-up cells, the solver retains mathematical integrity for particle tracking runs.

---
*PR created automatically by Jules for task [792961427861997609](https://jules.google.com/task/792961427861997609) started by @LokiMetaSmith*