### PR TITLE
fix: Resolve SIGFPE Divergence on Laminar Mesh Fallback

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -549,6 +549,8 @@ boundaryField
             content = re.sub(r"div\(phi,epsilon\).*?;", "", content)
             content = re.sub(r"div\(phi,omega\).*?;", "", content)
             content = re.sub(r"div\(phi,R\).*?;", "", content)
+            # Switch to upwind for U to ensure stability on coarse mesh without turbulent viscosity
+            content = re.sub(r"div\(phi,U\).*?;", "div(phi,U)      bounded Gauss upwind;", content)
         elif turbulence == "RNGkEpsilon":
             content = re.sub(r"div\(phi,omega\).*?;", "", content)
             content = re.sub(r"div\(phi,R\).*?;", "", content)
@@ -568,16 +570,16 @@ boundaryField
             content = f.read()
 
         if turbulence == "laminar":
-            content = content.replace('"(U|k|epsilon|omega)"', '"U"')
-            content = content.replace('"(k|epsilon|omega)" 1e-4;', '')
+            content = re.sub(r'"\(U\|k\|epsilon(?:\|omega)?\)"', '"U"', content)
+            content = re.sub(r'"\(k\|epsilon(?:\|omega)?\)"\s+[\d\.e\-\+]+;', '', content)
             # Remove relaxation factors for k, epsilon, omega
             content = re.sub(r"k\s+[\d\.]+;", "", content)
             content = re.sub(r"epsilon\s+[\d\.]+;", "", content)
             content = re.sub(r"omega\s+[\d\.]+;", "", content)
             content = re.sub(r"R\s+[\d\.]+;", "", content)
         elif turbulence == "RNGkEpsilon":
-            content = content.replace('"(U|k|epsilon|omega)"', '"(U|k|epsilon)"')
-            content = content.replace('"(k|epsilon|omega)" 1e-4;', '"(k|epsilon)" 1e-4;')
+            content = re.sub(r'"\(U\|k\|epsilon\|omega\)"', '"(U|k|epsilon)"', content)
+            content = re.sub(r'"\(k\|epsilon\|omega\)"\s+[\d\.e\-\+]+;', '"(k|epsilon)" 1e-4;', content)
             content = re.sub(r"omega\s+[\d\.]+;", "", content)
             content = re.sub(r"R\s+[\d\.]+;", "", content)
         elif turbulence == "kOmegaSST" or turbulence == "kOmegaSST_disabled":


### PR DESCRIPTION
This PR addresses the SIGFPE crashes that occur when the optimizer falls back to a laminar simulation due to low memory mesh scaling.

### The Problem
When falling back to a coarse mesh, the framework switches the `simulationType` to `laminar;`. However, it left the velocity divergence scheme (`div(phi,U)`) set to `linearUpwind` in `fvSchemes`. Without turbulent viscosity (`nut`) to provide numerical diffusion, high Reynolds number flows on coarse meshes become wildly unstable with `linearUpwind`, causing the velocity (`U`) residuals to explode to `1e+28` and eventually triggering a SIGFPE (division by zero) in the `p` matrix preconditioner.

### The Fix
1.  **Stable Upwind Scheme:** When the turbulence model is switched to `laminar`, the `div(phi,U)` scheme is now dynamically updated to `bounded Gauss upwind;` in `_update_fvSchemes`. This provides the necessary first-order numerical diffusion to keep the simulation stable.
2.  **Robust fvSolution Regex:** The string replacement logic in `_update_fvSolution` was hardcoded to look for `"(U|k|epsilon|omega)"` and failed to clean up solvers if the base template only used `"(U|k|epsilon)"` (e.g., for `RNGkEpsilon`). This has been refactored to use robust regex `re.sub` that handles both cases correctly.

---
*PR created automatically by Jules for task [17153572421688056697](https://jules.google.com/task/17153572421688056697) started by @LokiMetaSmith*