### PR TITLE
Fix fvSolution Epsilon Field Crash

### DIFF
--- a/corkscrewFilter/system/fvSolution
+++ b/corkscrewFilter/system/fvSolution
@@ -25,7 +25,31 @@ solvers
         relTol          0.01;
     }
 
-    "(U|k|epsilon)"
+    U
+    {
+        solver          smoothSolver;
+        smoother        symGaussSeidel;
+        tolerance       1e-6;
+        relTol          0.1;
+    }
+
+    k
+    {
+        solver          smoothSolver;
+        smoother        symGaussSeidel;
+        tolerance       1e-6;
+        relTol          0.1;
+    }
+
+    epsilon
+    {
+        solver          smoothSolver;
+        smoother        symGaussSeidel;
+        tolerance       1e-6;
+        relTol          0.1;
+    }
+
+    omega
     {
         solver          smoothSolver;
         smoother        symGaussSeidel;
@@ -44,7 +68,9 @@ SIMPLE
     {
         p               1e-4;
         U               1e-4;
-        "(k|epsilon)" 1e-4;
+        k               1e-4;
+        epsilon         1e-4;
+        omega           1e-4;
     }
 }
 
@@ -58,8 +84,8 @@ relaxationFactors
     {
         U               0.5;
         k               0.5;
-        epsilon               0.5;
-
+        epsilon         0.5;
+        omega           0.5;
     }
 }
 

--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -570,6 +570,18 @@ boundaryField
         template_path = os.path.join(self.case_dir, "system", "fvSolution.template")
         target_path = os.path.join(self.case_dir, "system", "fvSolution")
 
+        # If the template file exists but we are running a new version, it might be outdated.
+        # But we also don't want to overwrite custom user templates.
+        # Since we changed the base target_path format to use explicit blocks,
+        # let's overwrite the template if it uses the old regex block approach.
+        if os.path.exists(template_path):
+            with open(template_path, 'r') as f:
+                template_content = f.read()
+            if '"(U|k|epsilon)"' in template_content or '"(U|k|epsilon|omega)"' in template_content:
+                # The template is outdated, overwrite it with the new explicit-block version
+                if os.path.exists(target_path):
+                    shutil.copy2(target_path, template_path)
+
         # Recover from permanent modification if user lacks template
         if not os.path.exists(template_path) and os.path.exists(target_path):
             shutil.copy2(target_path, template_path)
@@ -582,21 +594,22 @@ boundaryField
         with open(target_path, 'r') as f:
             content = f.read()
 
+        def remove_block(text, block_name):
+            pattern_solver = r"\s*" + block_name + r"\s*\{[^}]+\}"
+            text = re.sub(pattern_solver, "", text)
+            pattern_line = r"^\s*" + block_name + r"\s+[\d\.e\-\+]+;\s*$"
+            text = re.sub(pattern_line, "", text, flags=re.MULTILINE)
+            return text
+
         if turbulence == "laminar":
-            content = re.sub(r'"\(U\|k\|epsilon(?:\|omega)?\)"', '"U"', content)
-            content = re.sub(r'"\(k\|epsilon(?:\|omega)?\)"\s+[\d\.e\-\+]+;', '', content)
-            # Remove relaxation factors for k, epsilon, omega
-            content = re.sub(r"k\s+[\d\.]+;", "", content)
-            content = re.sub(r"epsilon\s+[\d\.]+;", "", content)
-            content = re.sub(r"omega\s+[\d\.]+;", "", content)
-            content = re.sub(r"R\s+[\d\.]+;", "", content)
+            for field in ["k", "epsilon", "omega", "R"]:
+                content = remove_block(content, field)
         elif turbulence == "RNGkEpsilon":
-            content = re.sub(r'"\(U\|k\|epsilon\|omega\)"', '"(U|k|epsilon)"', content)
-            content = re.sub(r'"\(k\|epsilon\|omega\)"\s+[\d\.e\-\+]+;', '"(k|epsilon)" 1e-4;', content)
-            content = re.sub(r"omega\s+[\d\.]+;", "", content)
-            content = re.sub(r"R\s+[\d\.]+;", "", content)
+            for field in ["omega", "R"]:
+                content = remove_block(content, field)
         elif turbulence == "kOmegaSST" or turbulence == "kOmegaSST_disabled":
-            content = re.sub(r"R\s+[\d\.]+;", "", content)
+            for field in ["epsilon", "R"]:
+                content = remove_block(content, field)
 
         if cfd_settings and 'relaxation_factors' in cfd_settings:
             relax_factors = cfd_settings['relaxation_factors']


### PR DESCRIPTION
The CFD solver logic was crashing because it could not find explicit blocks for boundary fields (like `epsilon`) in `fvSolution/solvers` due to unsupported OpenFOAM regex interpretation in this specific context.

To resolve this issue robustly, the `fvSolution` template was migrated to utilize explicit blocks for all fields (`U`, `k`, `epsilon`, `omega`). Then, `foam_driver.py` was refactored to parse the file and programmatically strip out fields that are irrelevant to the active turbulence model (e.g., stripping `k` and `epsilon` if the simulation scales down to `laminar` mode). This ensures the generated dictionaries accurately represent the current physics constraints without relying on brittle regular expressions.

---
*PR created automatically by Jules for task [17019226688891073787](https://jules.google.com/task/17019226688891073787) started by @LokiMetaSmith*