### PR TITLE
fix: resolve SIGFPE crashes via fvSchemes U upwinding and fvSolution regex updates

### DIFF
--- a/corkscrewFilter/system/fvSolution.template
+++ b/corkscrewFilter/system/fvSolution.template
@@ -1,0 +1,92 @@
+/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  v2512                                 |
+|   \\  /    A nd           | Website:  www.openfoam.com                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      fvSolution;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+solvers
+{
+    p
+    {
+        solver          PCG;
+        preconditioner  DIC;
+        tolerance       1e-6;
+        relTol          0.01;
+    }
+
+    U
+    {
+        solver          smoothSolver;
+        smoother        symGaussSeidel;
+        tolerance       1e-6;
+        relTol          0.1;
+    }
+
+    k
+    {
+        solver          smoothSolver;
+        smoother        symGaussSeidel;
+        tolerance       1e-6;
+        relTol          0.1;
+    }
+
+    epsilon
+    {
+        solver          smoothSolver;
+        smoother        symGaussSeidel;
+        tolerance       1e-6;
+        relTol          0.1;
+    }
+
+    omega
+    {
+        solver          smoothSolver;
+        smoother        symGaussSeidel;
+        tolerance       1e-6;
+        relTol          0.1;
+    }
+}
+
+SIMPLE
+{
+    nNonOrthogonalCorrectors 2;
+    consistent      no;
+    pRefCell        0;
+    pRefValue       0;
+    residualControl
+    {
+        p               1e-4;
+        U               1e-4;
+        k               1e-4;
+        epsilon         1e-4;
+        omega           1e-4;
+    }
+}
+
+relaxationFactors
+{
+    fields
+    {
+        p               0.2;
+    }
+    equations
+    {
+        U               0.5;
+        k               0.5;
+        epsilon         0.5;
+        omega           0.5;
+    }
+}
+
+// ************************************************************************* //

--- a/fix.py
+++ b/fix.py
@@ -1,7 +1,0 @@
-with open('test/test_cloud_config.py', 'r') as f:
-    content = f.read()
-
-content = content.replace('self.assertIn("U0              (0 0 5.0);", content)', 'self.assertIn("U0              (0 0 5);", content)')
-
-with open('test/test_cloud_config.py', 'w') as f:
-    f.write(content)

--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -541,6 +541,8 @@ boundaryField
         elif turbulence == "RNGkEpsilon":
             content = re.sub(r"div\(phi,omega\).*?;", "", content)
             content = re.sub(r"div\(phi,R\).*?;", "", content)
+            # Upwind U to ensure stability on coarse/scaled meshes with turbulence enabled
+            content = re.sub(r"div\(phi,U\).*?;", "div(phi,U)      bounded Gauss upwind;", content)
 
             # Robustly inject if missing due to prior corrupted files (handles Windows CRLF and arbitrary spacing)
             if "div(phi,k)" not in content and "divSchemes" in content:
@@ -729,7 +731,7 @@ relaxationFactors
         if cfd_settings and 'relaxation_factors' in cfd_settings:
             relax_factors = cfd_settings['relaxation_factors']
             for factor_name, factor_value in relax_factors.items():
-                content = re.sub(rf"\b{factor_name}\s+[\d\.]+;", f"{factor_name}               {factor_value};", content)
+                content = re.sub(rf"\b{factor_name}\s+[\d\.\-e\+]+;", f"{factor_name}               {factor_value};", content)
 
         # Clean up empty lines created by regex sub and enforce Unix line endings for OpenFOAM in Podman
         cleaned = "\n".join([s for s in content.splitlines() if s.strip()])
@@ -1832,8 +1834,8 @@ cloudFunctions
                     content = re.sub(r"^\s*Cs\s+.*?$\n?", "", content, flags=re.MULTILINE)
 
                 if new_wall_func == "zeroGradient":
-                    content = re.sub(r"type\s+zeroGradient;\s*value\s+uniform\s+[\d\.\-e\+]+;", r"type            zeroGradient;", content)
-                    content = re.sub(r"type\s+zeroGradient;\s*value\s+\$internalField;", r"type            zeroGradient;", content)
+                    content = re.sub(r"type\s+zeroGradient;\s+value\s+uniform\s+[\d\.\-e\+]+;", r"type            zeroGradient;", content, flags=re.MULTILINE)
+                    content = re.sub(r"type\s+zeroGradient;\s+value\s+\$internalField;", r"type            zeroGradient;", content, flags=re.MULTILINE)
 
                 with open(field_path, "w") as f:
                     f.write(content)


### PR DESCRIPTION
Resolves FPE numerical crashes and blowups during OpenFOAM iterations on scaled geometries by upwinding the velocity field and properly updating OpenFOAM dictionaries.

---
*PR created automatically by Jules for task [5371611492618112728](https://jules.google.com/task/5371611492618112728) started by @LokiMetaSmith*