### PR TITLE
Fix OpenFOAM FPE crash in example_manifold_config.yaml and foam_drive…

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -730,8 +730,15 @@ relaxationFactors
 
         if cfd_settings and 'relaxation_factors' in cfd_settings:
             relax_factors = cfd_settings['relaxation_factors']
-            for factor_name, factor_value in relax_factors.items():
-                content = re.sub(rf"\b{factor_name}\s+[\d\.\-e\+]+;", f"{factor_name}               {factor_value};", content)
+            parts = content.split("relaxationFactors", 1)
+            if len(parts) > 1:
+                relax_block = parts[1]
+                for factor_name, factor_value in relax_factors.items():
+                    relax_block = re.sub(rf"\b{factor_name}\s+[\d\.\-e\+]+;", f"{factor_name}               {factor_value};", relax_block)
+                content = parts[0] + "relaxationFactors" + relax_block
+            else:
+                for factor_name, factor_value in relax_factors.items():
+                    content = re.sub(rf"\b{factor_name}\s+[\d\.\-e\+]+;", f"{factor_name}               {factor_value};", content)
 
         # Clean up empty lines created by regex sub and enforce Unix line endings for OpenFOAM in Podman
         cleaned = "\n".join([s for s in content.splitlines() if s.strip()])


### PR DESCRIPTION
…r.py

1. Decreased the initial internal fields for `k` and `epsilon` from large uniform values (`0.375` and `14.855`) to small non-zero values (`1e-5`). This correctly prevents Floating Point Exception (FPE) crashes in `epsilonWallFunction` during OpenFOAM `simpleFoam` solver iterations on complex/coarse geometries.
2. Fixed a regex bug in `foam_driver.py`'s `_update_fvSolution` where `relaxation_factors` from the YAML config were accidentally overwriting `residualControl` tolerances in the `SIMPLE` loop block. The replacement is now safely scoped to the `relaxationFactors` section.