### PR TITLE
Add secure IFF roster generation scripts and Zoho Deluge webhook example

### DIFF
--- a/public/iff-roster.json
+++ b/public/iff-roster.json
@@ -1,0 +1,7 @@
+{
+  "valid_hashes": [
+    "f8d94a250335f4f5987381b617f497c6b142f22cf9f5dd00f6f8df9edd4e516a",
+    "42a5e5d28b5c6f90ec58d62fd170875c292d4c58eec58dd0476ccc32fc9bfe53",
+    "276e1ead3ba6b66a1ca83ebdc4a1ca67a777d1515493d63cb73bfdc44b37a34c"
+  ]
+}

--- a/scripts/zoho_integration/generate_roster.py
+++ b/scripts/zoho_integration/generate_roster.py
@@ -1,0 +1,51 @@
+import hashlib
+import json
+import csv
+import os
+
+def generate_roster():
+    # 1. Configuration
+    input_file = os.path.join(os.path.dirname(__file__), 'raw_emails.csv')
+    output_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'public')
+    output_file = os.path.join(output_dir, 'iff-roster.json')
+
+    # Using an environment variable for the salt, with a fallback for testing
+    salt = os.environ.get('IFF_ROSTER_SALT', 'iff_secret_2026')
+
+    # Ensure output directory exists
+    os.makedirs(output_dir, exist_ok=True)
+
+    hashed_roster = []
+
+    try:
+        # 2. Read raw emails from CSV
+        with open(input_file, mode='r', encoding='utf-8') as file:
+            reader = csv.DictReader(file)
+            for row in reader:
+                # Assuming the column name is 'Email' or similar
+                email = row.get('Email') or row.get('email')
+                if not email:
+                    continue
+
+                # 3. Normalize: Lowercase and strip whitespace
+                clean_email = email.strip().lower()
+
+                # 4. Salt
+                salted_email = f"{clean_email}+{salt}"
+
+                # 5. Hash (SHA-256)
+                email_hash = hashlib.sha256(salted_email.encode('utf-8')).hexdigest()
+                hashed_roster.append(email_hash)
+
+        # 6. Output to static site build folder
+        with open(output_file, 'w') as f:
+            json.dump({"valid_hashes": hashed_roster}, f, indent=2)
+
+        print(f"Successfully generated hashed roster with {len(hashed_roster)} entries.")
+        print(f"Output saved to: {output_file}")
+
+    except Exception as e:
+        print(f"Error generating roster: {e}")
+
+if __name__ == "__main__":
+    generate_roster()

--- a/scripts/zoho_integration/raw_emails.csv
+++ b/scripts/zoho_integration/raw_emails.csv
@@ -1,0 +1,4 @@
+Email,Name
+Loki@example.com,Loki
+tinkerer@example.com,Tinkerer
+  John.Doe@EXAMPLE.com ,John Doe

--- a/scripts/zoho_integration/zoho_webhook_example.dg
+++ b/scripts/zoho_integration/zoho_webhook_example.dg
@@ -1,0 +1,59 @@
+// Zoho Deluge Webhook Example for IFF Roster Integration
+// This script checks if a newly registered/updated Zoho user is a verified IFF affiliate.
+
+// Assumption: The Zoho user object is available as `zoho_customer` or similar
+// Replace with the actual variable representing the user in your workflow
+user_email = zoho_customer.get("email");
+
+// Define the salt - must exactly match the salt used in the Python generation script
+// If the Python script used the fallback, this should be 'iff_secret_2026'
+salt = "iff_secret_2026";
+
+if(user_email != null)
+{
+    // 1. Normalize: strip trailing/leading whitespace and lowercase
+    clean_email = user_email.trim().toLowerCase();
+
+    // 2. Salt the email (format: email+salt)
+    salted_email = clean_email + "+" + salt;
+
+    // 3. Hash the salted email using Deluge's built-in encryption (SHA-256)
+    email_hash = zoho.encryption.sha256(salted_email);
+
+    // 4. Fetch the static IFF roster
+    // Replace the URL with the actual public URL where your static site hosts iff-roster.json
+    roster_url = "https://ideaforge.org/iff-roster.json";
+
+    iff_response = invokeurl
+    [
+        url :roster_url
+        type :GET
+    ];
+
+    if(iff_response != null && iff_response.get("valid_hashes") != null)
+    {
+        // 5. Verify and Update
+        if(iff_response.get("valid_hashes").contains(email_hash))
+        {
+            // Success! They are an IFF affiliate.
+            // Trigger Zoho to update a field, apply a discount, or grant access.
+            info "IFF Member Verified";
+
+            // Example: updating a custom boolean field on the user record
+            // update_map = {"Is_IFF_Affiliate": true};
+            // zoho.crm.updateRecord("Contacts", zoho_customer.get("id"), update_map);
+        }
+        else
+        {
+            info "Not an IFF Member";
+        }
+    }
+    else
+    {
+        info "Error: Could not fetch or parse IFF roster from " + roster_url;
+    }
+}
+else
+{
+    info "Error: User email is null";
+}


### PR DESCRIPTION
This PR implements the requested "Salt & Scrub" secure roster sync for the IFF and Makerspace integration.

It provides a Python script that parses a dummy CSV file containing raw emails, strips whitespace, converts to lowercase, appends a salt (defaulting to `iff_secret_2026` but reading from the `IFF_ROSTER_SALT` environment variable), and generates SHA-256 hashes. These are then saved directly to `public/iff-roster.json`.

It also provides the Zoho Deluge webhook example as a `.dg` file, demonstrating how to perform the identical normalization and salting steps on a Zoho User object before verifying the hash against the static `iff-roster.json` file via a GET request.

---
*PR created automatically by Jules for task [5658916036505735741](https://jules.google.com/task/5658916036505735741) started by @LokiMetaSmith*