### PR TITLE
Fix Podman memory crash and solver timeout

### DIFF
--- a/configs/corkscrew_config.yaml
+++ b/configs/corkscrew_config.yaml
@@ -17,7 +17,7 @@ geometry:
     slit_chamfer_height: { type: "float", min: 0.1, max: 1.0, default: 0.5 }
     add_layers: { type: "bool", default: true }
     GENERATE_CFD_VOLUME: { type: "bool", default: true, constant: true }
-    target_cell_size: { type: "float", min: 1.5, max: 5.0, default: 2.5 }
+    target_cell_size: { type: "float", min: 1.5, max: 5.0, default: 4.0 }
 
 physics:
   solver: "simpleFoam"

--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -1849,13 +1849,13 @@ cloudFunctions
                 self._generate_decomposeParDict(num_processors=solve_procs, method=solve_method)
                 if not self.run_command(["decomposePar", "-force"], log_file=log_file, description="Decomposing Domain"): return False
                 cmd = ["mpirun", "-np", str(solve_procs), "simpleFoam", "-parallel"]
-                if not self.run_command(cmd, log_file=log_file, description=f"Solving CFD (Parallel {solve_procs} CPUs)", timeout=7200): return False
+                if not self.run_command(cmd, log_file=log_file, description=f"Solving CFD (Parallel {solve_procs} CPUs)", timeout=14400): return False
                 if not self.run_command(["reconstructPar", "-latestTime"], log_file=log_file, description="Reconstructing Domain"): return False
                 for proc_dir in glob.glob(os.path.join(self.case_dir, "processor*")):
                     shutil.rmtree(proc_dir, ignore_errors=True)
                 return True
             else:
-                return self.run_command(["simpleFoam"], log_file=log_file, description="Solving CFD", timeout=7200)
+                return self.run_command(["simpleFoam"], log_file=log_file, description="Solving CFD", timeout=14400)
 
         success = _execute()
 
@@ -2196,7 +2196,7 @@ boundaryField
             # Turbulence is KEPT ON for stochasticDispersionRAS
 
             # 4. Run Solver
-            return self.run_command(["icoUncoupledKinematicParcelFoam"], log_file=log_file, description="Particle Tracking", timeout=7200)
+            return self.run_command(["icoUncoupledKinematicParcelFoam"], log_file=log_file, description="Particle Tracking", timeout=14400)
 
     def generate_vtk(self):
         """

--- a/repair_podman.ps1
+++ b/repair_podman.ps1
@@ -80,7 +80,24 @@ if (!$podmanInstalled) {
     Write-Host "Podman is already installed." -ForegroundColor Green
 }
 
-# 3. Kill lingering Podman and API proxy processes BEFORE attempting to delete files
+# 3. Try Safe Restart First
+Write-Host "Attempting safe restart of Podman machine..." -ForegroundColor Yellow
+if (Get-Command "podman" -ErrorAction SilentlyContinue) {
+    podman machine stop 2>$null
+    wsl --shutdown
+    Start-Sleep -Seconds 3
+    podman machine start
+    if ($LASTEXITCODE -eq 0) {
+        podman info >$null 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "Safe restart successful. Podman is responsive." -ForegroundColor Green
+            exit 0
+        }
+    }
+}
+Write-Host "Safe restart failed or Podman not responsive. Proceeding with full repair..." -ForegroundColor Yellow
+
+# 4. Kill lingering Podman and API proxy processes BEFORE attempting to delete files
 Write-Host "Checking for lingering Podman and proxy processes..." -ForegroundColor Yellow
 $lingeringProcesses = Get-Process -Name "*sshproxy*", "*gvproxy*", "podman*" -ErrorAction SilentlyContinue
 if ($lingeringProcesses) {
@@ -90,7 +107,7 @@ if ($lingeringProcesses) {
     }
 }
 
-# 4. Stop and remove existing Podman machines
+# 5. Stop and remove existing Podman machines
 Write-Host "Cleaning up existing Podman machines..." -ForegroundColor Yellow
 if (Get-Command "podman" -ErrorAction SilentlyContinue) {
     $machines = podman machine list --format "{{.Name}}" 2>$null
@@ -112,7 +129,7 @@ if (Get-Command "podman" -ErrorAction SilentlyContinue) {
     }
 }
 
-# 5. Shut down WSL and ensure it is stopped
+# 6. Shut down WSL and ensure it is stopped
 Write-Host "Shutting down WSL to clear locks..." -ForegroundColor Yellow
 wsl --shutdown
 Start-Sleep -Seconds 3
@@ -129,7 +146,7 @@ while ($wslRetryCount -lt 5) {
     $wslRetryCount++
 }
 
-# 6. Dynamically find and unregister leftover Podman WSL distributions
+# 7. Dynamically find and unregister leftover Podman WSL distributions
 Write-Host "Checking for lingering Podman WSL distributions..." -ForegroundColor Yellow
 
 # Explicitly unregister known default names in case `wsl --list` fails or omits them
@@ -149,7 +166,7 @@ if ($wslList) {
     }
 }
 
-# 7. Forcefully clean up Windows Hyper-V VMs
+# 8. Forcefully clean up Windows Hyper-V VMs
 Write-Host "Checking for lingering Hyper-V VMs..." -ForegroundColor Yellow
 if (Get-Command "Get-VM" -ErrorAction SilentlyContinue) {
     $vms = Get-VM -Name "podman-machine-default*" -ErrorAction SilentlyContinue
@@ -162,7 +179,7 @@ if (Get-Command "Get-VM" -ErrorAction SilentlyContinue) {
     }
 }
 
-# 8. Forcefully clean Podman configuration directories
+# 9. Forcefully clean Podman configuration directories
 Write-Host "Cleaning up lingering Podman machine configuration files..." -ForegroundColor Yellow
 $localMachineConf = "$env:USERPROFILE\.local\share\containers\podman\machine"
 $configMachineConf = "$env:USERPROFILE\.config\containers\podman\machine"
@@ -174,7 +191,7 @@ if (Test-Path $configMachineConf) {
     Remove-Item -Recurse -Force $configMachineConf -ErrorAction SilentlyContinue
 }
 
-# 9. Forcefully clean lingering Podman system connections
+# 10. Forcefully clean lingering Podman system connections
 Write-Host "Cleaning up lingering Podman system connections..." -ForegroundColor Yellow
 if (Get-Command "podman" -ErrorAction SilentlyContinue) {
     $connections = podman system connection list --format "{{.Name}}" 2>$null
@@ -194,7 +211,7 @@ if (Get-Command "podman" -ErrorAction SilentlyContinue) {
     }
 }
 
-# 10. Initialize and start a fresh Podman machine
+# 11. Initialize and start a fresh Podman machine
 Write-Host "Initializing a fresh Podman machine..." -ForegroundColor Cyan
 podman machine init --memory 8192
 if ($LASTEXITCODE -ne 0) {
@@ -209,7 +226,7 @@ if ($LASTEXITCODE -ne 0) {
     exit 1
 }
 
-# 11. Verify functionality
+# 12. Verify functionality
 Write-Host "Verifying Podman installation and machine status..." -ForegroundColor Cyan
 podman info
 


### PR DESCRIPTION
Fixes two systemic issues with the optimization run:
1. Podman VM crashing due to memory leak (WSL caching). Fixed by making `repair_podman.ps1` safely restart the VM, avoiding full re-installation.
2. Solver taking too long on high resolution meshes. Fixed by coarsening the default `target_cell_size` and increasing the solver timeout to 4 hours.

---
*PR created automatically by Jules for task [4768474539735934914](https://jules.google.com/task/4768474539735934914) started by @LokiMetaSmith*