### PR TITLE
fix: Use correct encoding check for console spinner fallback

### DIFF
--- a/optimizer/utils.py
+++ b/optimizer/utils.py
@@ -200,7 +200,8 @@ def run_command_with_spinner(cmd, log_file_path, cwd=None, description="Processi
                     output_str = f"{spinner[idx]} {description}{progress_str}"
 
                     try:
-                        output_str.encode('utf-8')
+                        encoding = sys.stdout.encoding or 'utf-8'
+                        output_str.encode(encoding)
                     except UnicodeEncodeError:
                         progress_str = f" [{state.current_phase}: {fallback_blocks_str} {time_str}]"
                         output_str = f"{spinner[idx]} {description}{progress_str}"


### PR DESCRIPTION
Fixes a `UnicodeEncodeError` in `optimizer/utils.py` that occurred on systems with restricted terminal encodings (e.g., Windows with `cp1252`).

The issue was that the `run_command_with_spinner` loop attempted to write block drawing characters (`▃`) to standard output. While there was a `try...except UnicodeEncodeError:` block intended to gracefully fall back to ASCII characters (like `.`), it incorrectly checked against `'utf-8'` (which always succeeds on valid strings). The commit updates this to explicitly check `sys.stdout.encoding` instead.

---
*PR created automatically by Jules for task [12263705251028597140](https://jules.google.com/task/12263705251028597140) started by @LokiMetaSmith*