### PR TITLE
fix: stabilize initial turbulence fields to prevent FPE

### DIFF
--- a/configs/example_manifold_config.yaml
+++ b/configs/example_manifold_config.yaml
@@ -58,10 +58,10 @@ cfd_settings:
     k: "kqRWallFunction"
   initial_fields:
     k:
-      internalField: "uniform 1e-5"
+      internalField: "uniform 0.375"
       wallFunction: "kqRWallFunction"
     epsilon:
-      internalField: "uniform 1e-5"
+      internalField: "uniform 14.855"
       wallFunction: "epsilonWallFunction"
   relaxation_factors:
     p: 0.2


### PR DESCRIPTION
To completely prevent Floating Point Exception (sigFpe) crashes during `simpleFoam` when turbulent kinetic energy (`k`) explodes (e.g. `min: -1.07546e+95 max: 3.45946e+110`) on automated meshes, this commit applies physically realistic initial conditions.

Specifically, it updates `configs/example_manifold_config.yaml` to initialize `k` to `0.375` and `epsilon` to `14.855` (instead of `1e-5`). Providing a realistic initial guess prevents massive shear layer gradients from generating negative `k` values and NaN divergences during the initial steady-state iterations.