### PR TITLE
fix: allow mpirun as root for podman CFD parallelization

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -1725,7 +1725,7 @@ cloudFunctions
 
             if not success_decompose: return False
 
-            cmd = ["mpirun", "-np", str(mesh_procs), "snappyHexMesh", "-overwrite", "-parallel"]
+            cmd = ["mpirun", "--allow-run-as-root", "-np", str(mesh_procs), "snappyHexMesh", "-overwrite", "-parallel"]
             if not self.run_command(cmd, log_file=log_file, description="Meshing (snappyHexMesh Parallel)", timeout=3600):
                 print("Error: Meshing failed. Boundary layers are critical, design rejected.")
                 return False
@@ -1848,7 +1848,7 @@ cloudFunctions
             if solve_procs > 1:
                 self._generate_decomposeParDict(num_processors=solve_procs, method=solve_method)
                 if not self.run_command(["decomposePar", "-force"], log_file=log_file, description="Decomposing Domain"): return False
-                cmd = ["mpirun", "-np", str(solve_procs), "simpleFoam", "-parallel"]
+                cmd = ["mpirun", "--allow-run-as-root", "-np", str(solve_procs), "simpleFoam", "-parallel"]
                 if not self.run_command(cmd, log_file=log_file, description=f"Solving CFD (Parallel {solve_procs} CPUs)", timeout=14400): return False
                 if not self.run_command(["reconstructPar", "-latestTime"], log_file=log_file, description="Reconstructing Domain"): return False
                 for proc_dir in glob.glob(os.path.join(self.case_dir, "processor*")):


### PR DESCRIPTION
To successfully execute parallel OpenFOAM optimization loops within a Docker or Podman container, this commit allows `mpirun` to execute as root. Containerized environments run as root by default, which triggers an OpenMPI safety rejection (`mpirun has detected an attempt to run as root...`).

Specifically, it appends the `--allow-run-as-root` flag to the `mpirun` subprocess commands in `optimizer/foam_driver.py` for both the `snappyHexMesh` and `simpleFoam` parallel execution paths.

This pairs with previous commits to stabilize the CFD solver using 1st-order schemes (`bounded Gauss upwind`), limited non-orthogonal correction (`0.33`), and forgiving relaxation factors (`0.5` and `0.2`) to prevent floating-point exceptions (FPEs) on ugly LLM-generated geometries.