### PR TITLE
Fix Podman connection errors and OpenFOAM particle tracking SIGFPEs

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -327,13 +327,13 @@ class FoamDriver:
             elif field_name == "nut":
                 dimensions = "[0 2 -1 0 0 0 0]"
 
-            header = f"""/*--------------------------------*- C++ -*----------------------------------*\
+            header = f"""/*--------------------------------*- C++ -*----------------------------------*\\
 | =========                 |                                                 |
 | \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
 |  \\    /   O peration     | Version:  v2512                                 |
 |   \\  /    A nd           | Website:  www.openfoam.com                      |
 |    \\/     M anipulation  |                                                 |
-\*---------------------------------------------------------------------------*/
+\\*---------------------------------------------------------------------------*/
 FoamFile
 {{
     version     2.0;
@@ -512,6 +512,7 @@ boundaryField
 
         if turbulence == "laminar" or turbulence == "kOmegaSST_disabled":
             # Cleanly disable turbulence without removing the underlying model.
+            content = re.sub(r"simulationType\s+.*?;", "simulationType  RAS;", content)
             content = re.sub(r"turbulence\s+.*?;", "turbulence      off;", content)
         else:
             content = re.sub(r"simulationType\s+.*?;", "simulationType  RAS;", content)
@@ -1061,12 +1062,12 @@ method          {method};
         Generates system/topoSetDict using Jinja2.
         skip_io: if True, skips generation of inlet/outlet face sets.
         """
-        template_str = """/*--------------------------------*- C++ -*----------------------------------*\\
+        template_str = r"""/*--------------------------------*- C++ -*----------------------------------*\
 | =========                 |                                                 |
-| \      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
-|  \    /   O peration     | Version:  v2512                                 |
-|   \  /    A nd           | Website:  www.openfoam.com                      |
-|    \/     M anipulation  |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  v2512                                 |
+|   \\  /    A nd           | Website:  www.openfoam.com                      |
+|    \\/     M anipulation  |                                                 |
 \*---------------------------------------------------------------------------*/
 FoamFile
 {
@@ -1270,7 +1271,7 @@ patches
         """
         Generates constant/kinematicCloudProperties with size binning and spatial binning using Jinja2.
         """
-        template_str = """/*--------------------------------*- C++ -*----------------------------------*\\
+        template_str = r"""/*--------------------------------*- C++ -*----------------------------------*\
         Generates constant/kinematicCloudProperties with dynamic size binning and spatial binning.
         """
         # Default fallback values
@@ -1296,7 +1297,7 @@ patches
         area_ratio = inlet_area_m2 / baseline_area
         parcels_per_sec = int(5000 * area_ratio)
 
-        template_str = """/*--------------------------------*- C++ -*----------------------------------*\\
+        template_str = r"""/*--------------------------------*- C++ -*----------------------------------*\
 | =========                 |                                                 |
 | \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
 |  \\    /   O peration     | Version:  v2512                                 |
@@ -2211,6 +2212,7 @@ boundaryField
             if not success and was_using_dispersion:
                 print("Particle tracking failed with dispersion. Attempting to recover by disabling dispersion model...")
                 self._generate_kinematicCloudProperties(bin_config, turbulence="force_laminar_fallback")
+                self._update_turbulence_properties("laminar")
                 success = self.run_command(["icoUncoupledKinematicParcelFoam"], log_file=log_file, description="Particle Tracking (Recovery)", timeout=14400)
 
             return success

--- a/optimizer/simulation_runner.py
+++ b/optimizer/simulation_runner.py
@@ -290,6 +290,11 @@ def run_simulation(scad_driver, foam_driver, params, output_stl_name="corkscrew_
     vtk_zip_path = None
 
     if not dry_run and not skip_cfd:
+        # Override turbulence if defined in config
+        cfd_settings = foam_driver.config.get('cfd_settings', {})
+        if cfd_settings and 'turbulence_model' in cfd_settings:
+            turbulence = cfd_settings['turbulence_model']
+
         foam_driver.prepare_case(keep_mesh=reuse_mesh, turbulence=turbulence)
 
         # Prepare Bin Configuration for Meshing/Tracking

--- a/optimizer/utils.py
+++ b/optimizer/utils.py
@@ -242,7 +242,10 @@ def run_command_with_spinner(cmd, log_file_path, cwd=None, description="Processi
             # Catch all exceptions so we can safely kill the process and join the thread
             # before the file descriptor is closed.
             process.kill()
-            reader_thread.join()
+            try:
+                reader_thread.join()
+            except Exception:
+                pass
             if isinstance(e, KeyboardInterrupt):
                 sys.stdout.write("\nProcess interrupted by user.\n")
             else:


### PR DESCRIPTION
Fixes several issues discovered with the Podman optimization loop:
- Podman network failures (e.g. exit codes 125, 126) resolving from orphaned processes not cleaned up when hitting SIGINT / Timeout due to unhandled exceptions when joining threads.
- `icoUncoupledKinematicParcelFoam` crashing with SIGFPE due to missing `epsilon` field (or misconfigured `turbulenceProperties`) because `turbulence` was implicitly passed as "laminar" during transient case preparation despite the config requesting `RNGkEpsilon`.
- Handled Python syntax warnings regarding invalid string escape sequences.

---
*PR created automatically by Jules for task [11419514439656758173](https://jules.google.com/task/11419514439656758173) started by @LokiMetaSmith*