### PR TITLE
Suppress duplicate "Unexpected error" logs for known subprocess failures

### DIFF
--- a/optimizer/utils.py
+++ b/optimizer/utils.py
@@ -248,7 +248,7 @@ def run_command_with_spinner(cmd, log_file_path, cwd=None, description="Processi
                 pass
             if isinstance(e, KeyboardInterrupt):
                 sys.stdout.write("\nProcess interrupted by user.\n")
-            else:
+            elif not isinstance(e, (subprocess.CalledProcessError, subprocess.TimeoutExpired)):
                 sys.stdout.write(f"\nUnexpected error executing {' '.join(cmd)}: {e}\n")
             raise
 


### PR DESCRIPTION
This commit fixes a logging issue where expected subprocess failures (like `blockMesh` failing or `snappyHexMesh` timing out) would trigger a generic "Unexpected error executing..." stack trace printout from the `run_command_with_spinner` utility function before raising the exception up. Since `foam_driver.py` already handles `subprocess.CalledProcessError` and `TimeoutExpired` to log standard OpenFOAM failure messages, this suppression avoids confusing duplicate logs for the user.

---
*PR created automatically by Jules for task [6886284056337222022](https://jules.google.com/task/6886284056337222022) started by @LokiMetaSmith*