### PR TITLE
Fix UnicodeEncodeError crashes when printing emojis

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -9,7 +9,7 @@ import contextlib
 import shlex
 import numpy as np
 import jinja2
-from utils import run_command_with_spinner
+from utils import run_command_with_spinner, safe_print
 
 class FoamDriver:
     def __init__(self, case_dir, config=None, template_dir=None, container_engine="auto", num_processors=1, verbose=False):
@@ -2057,7 +2057,7 @@ cloudFunctions
 
         best = None
         for strategy in STRATEGIES:
-            print(f"\n🚀 Trying solver strategy: {strategy['name']}")
+            safe_print(f"\n🚀 Trying solver strategy: {strategy['name']}")
 
             # 1. Configure turbulence model
             self._update_turbulence_properties(strategy["turbulence"])
@@ -2121,12 +2121,12 @@ cloudFunctions
             print(f"Strategy {strategy['name']} completed with score={score:.1f} (success={success})")
 
             if success and score > 80:
-                print("✅ High quality run found, exiting early.")
+                safe_print("✅ High quality run found, exiting early.")
                 break
 
         if results:
             best = max(results, key=lambda r: r["score"])
-            print(f"🏆 Best run: {best['strategy']} (score={best['score']:.1f})")
+            safe_print(f"🏆 Best run: {best['strategy']} (score={best['score']:.1f})")
 
             import json
             with open(os.path.join(self.case_dir, "run_results.json"), "w") as f:

--- a/optimizer/utils.py
+++ b/optimizer/utils.py
@@ -310,3 +310,18 @@ def get_container_memory_gb(container_tool=None):
             print(f"Warning: Failed to query Docker memory: {e}")
 
     return mem_gb
+
+def safe_print(text: str):
+    """
+    Safely prints text containing emojis or special characters.
+    Gracefully degrades to the terminal encoding if it (like cp1252 on Windows)
+    does not support them, preventing UnicodeEncodeError crashes.
+    """
+    try:
+        encoding = sys.stdout.encoding or 'utf-8'
+        text.encode(encoding)
+        print(text)
+    except UnicodeEncodeError:
+        # Strip characters that can't be encoded
+        safe_text = text.encode(encoding, 'ignore').decode(encoding)
+        print(safe_text)


### PR DESCRIPTION
This branch fixes the issue where `optimizer/main.py` crashes on Windows terminals that use limited encodings like `cp1252` when trying to print emojis.

- Added `safe_print` in `optimizer/utils.py`.
- Updated `optimizer/foam_driver.py` to import and use `safe_print` for logs containing emojis.

---
*PR created automatically by Jules for task [6152150487313802654](https://jules.google.com/task/6152150487313802654) started by @LokiMetaSmith*