### PR TITLE
Fix simpleFoam SIGFPE division-by-zero crashes due to missing turbule…

### DIFF
--- a/corkscrewFilter/0.orig/epsilon
+++ b/corkscrewFilter/0.orig/epsilon
@@ -28,12 +28,16 @@ boundaryField
 
     clean_outlet
     {
-        type            zeroGradient;
+        type            inletOutlet;
+        inletValue      uniform 1e-6;
+        value           uniform 1e-6;
     }
 
     dust_outlet
     {
-        type            zeroGradient;
+        type            inletOutlet;
+        inletValue      uniform 1e-6;
+        value           uniform 1e-6;
     }
 
     corkscrew
@@ -50,7 +54,9 @@ boundaryField
 
     ".*"
     {
-        type            zeroGradient;
+        type            inletOutlet;
+        inletValue      uniform 1e-6;
+        value           uniform 1e-6;
     }
 
 }

--- a/corkscrewFilter/0.orig/k
+++ b/corkscrewFilter/0.orig/k
@@ -28,12 +28,16 @@ boundaryField
 
     clean_outlet
     {
-        type            zeroGradient;
+        type            inletOutlet;
+        inletValue      uniform 1e-6;
+        value           uniform 1e-6;
     }
 
     dust_outlet
     {
-        type            zeroGradient;
+        type            inletOutlet;
+        inletValue      uniform 1e-6;
+        value           uniform 1e-6;
     }
 
     corkscrew
@@ -50,7 +54,9 @@ boundaryField
 
     ".*"
     {
-        type            zeroGradient;
+        type            inletOutlet;
+        inletValue      uniform 1e-6;
+        value           uniform 1e-6;
     }
 
 }

--- a/corkscrewFilter/0.orig/nut
+++ b/corkscrewFilter/0.orig/nut
@@ -28,12 +28,16 @@ boundaryField
 
     clean_outlet
     {
-        type            zeroGradient;
+        type            inletOutlet;
+        inletValue      uniform 1e-7;
+        value           uniform 1e-7;
     }
 
     dust_outlet
     {
-        type            zeroGradient;
+        type            inletOutlet;
+        inletValue      uniform 1e-7;
+        value           uniform 1e-7;
     }
 
     corkscrew
@@ -50,7 +54,9 @@ boundaryField
 
     ".*"
     {
-        type            zeroGradient;
+        type            inletOutlet;
+        inletValue      uniform 1e-7;
+        value           uniform 1e-7;
     }
 
 }

--- a/fix_inletoutlet.py
+++ b/fix_inletoutlet.py
@@ -1,0 +1,18 @@
+with open("optimizer/foam_driver.py", "r") as f:
+    content = f.read()
+
+old_code = """                    if field in ['k', 'epsilon', 'omega', 'nut'] and "type            calculated;" in block_content:
+                        default_val = '1e-7' if field == 'nut' else '1e-6'
+                        blocks[patch_name] = f"type            inletOutlet;\\n        inletValue      uniform {default_val};\\n        value           uniform {default_val};\""""
+
+new_code = """                    if field in ['k', 'epsilon', 'omega', 'nut'] and ("type            calculated;" in block_content or "type            zeroGradient;" in block_content):
+                        default_val = '1e-7' if field == 'nut' else '1e-6'
+                        blocks[patch_name] = f"type            inletOutlet;\\n        inletValue      uniform {default_val};\\n        value           uniform {default_val};\""""
+
+if old_code in content:
+    content = content.replace(old_code, new_code)
+    with open("optimizer/foam_driver.py", "w") as f:
+        f.write(content)
+    print("Successfully replaced.")
+else:
+    print("Old code not found.")

--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -594,7 +594,7 @@ boundaryField
                 # Avoid walls
                 p_type = boundaries.get(patch_name, {}).get("type")
                 if p_type != "wall":
-                    if field in ['k', 'epsilon', 'omega', 'nut'] and "type            calculated;" in block_content:
+                    if field in ['k', 'epsilon', 'omega', 'nut'] and ("type            calculated;" in block_content or "type            zeroGradient;" in block_content):
                         default_val = '1e-7' if field == 'nut' else '1e-6'
                         blocks[patch_name] = f"type            inletOutlet;\n        inletValue      uniform {default_val};\n        value           uniform {default_val};"
 

--- a/test_fvschemes.py
+++ b/test_fvschemes.py
@@ -1,0 +1,15 @@
+import yaml
+from optimizer.foam_driver import FoamDriver
+import os
+os.environ["PYTHONPATH"] = "optimizer"
+
+with open("configs/example_manifold_config.yaml", "r") as f:
+    config = yaml.safe_load(f)
+
+driver = FoamDriver("corkscrewFilter", config=config)
+
+# Run fvSchemes update
+driver._update_fvSchemes("kOmegaSST", "bad")
+
+with open(os.path.join(driver.case_dir, "system", "fvSchemes")) as f:
+    print(f.read())

--- a/test_fvschemes2.py
+++ b/test_fvschemes2.py
@@ -1,0 +1,15 @@
+import yaml
+from optimizer.foam_driver import FoamDriver
+import os
+os.environ["PYTHONPATH"] = "optimizer"
+
+with open("configs/example_manifold_config.yaml", "r") as f:
+    config = yaml.safe_load(f)
+
+driver = FoamDriver("corkscrewFilter", config=config)
+
+# Run fvSchemes update
+driver._update_fvSchemes("RNGkEpsilon", "bad")
+
+with open(os.path.join(driver.case_dir, "system", "fvSchemes")) as f:
+    print(f.read())

--- a/test_fvsolution.py
+++ b/test_fvsolution.py
@@ -1,0 +1,15 @@
+import yaml
+from optimizer.foam_driver import FoamDriver
+import os
+os.environ["PYTHONPATH"] = "optimizer"
+
+with open("configs/example_manifold_config.yaml", "r") as f:
+    config = yaml.safe_load(f)
+
+driver = FoamDriver("corkscrewFilter", config=config)
+
+# Run fvSolution update
+driver._update_fvSolution("kOmegaSST", config.get('cfd_settings', {}), {"p": 0.1, "U": 0.3, "k": 0.3, "omega": 0.3})
+
+with open(os.path.join(driver.case_dir, "system", "fvSolution")) as f:
+    print(f.read())

--- a/test_fvsolution2.py
+++ b/test_fvsolution2.py
@@ -1,0 +1,15 @@
+import yaml
+from optimizer.foam_driver import FoamDriver
+import os
+os.environ["PYTHONPATH"] = "optimizer"
+
+with open("configs/example_manifold_config.yaml", "r") as f:
+    config = yaml.safe_load(f)
+
+driver = FoamDriver("corkscrewFilter", config=config)
+
+# Run fvSolution update
+driver._update_fvSolution("RNGkEpsilon", config.get('cfd_settings', {}), {"p": 0.15, "U": 0.4, "k": 0.4, "epsilon": 0.4})
+
+with open(os.path.join(driver.case_dir, "system", "fvSolution")) as f:
+    print(f.read())

--- a/test_nan.py
+++ b/test_nan.py
@@ -1,0 +1,17 @@
+import yaml
+from optimizer.foam_driver import FoamDriver
+import os
+os.environ["PYTHONPATH"] = "optimizer"
+
+with open("configs/example_manifold_config.yaml", "r") as f:
+    config = yaml.safe_load(f)
+
+driver = FoamDriver("corkscrewFilter", config=config)
+
+# Generate fields
+driver._generate_turbulence_fields(os.path.join(driver.case_dir, "0.orig"), config.get('cfd_settings', {}))
+driver._apply_boundary_conditions(os.path.join(driver.case_dir, "0.orig"))
+
+print("epsilon value for inlet:")
+with open(os.path.join(driver.case_dir, "0.orig", "epsilon")) as f:
+    print([line for line in f if "value" in line])


### PR DESCRIPTION
…nce fields

- Explicitly inject missing turbulence base fields (`nut`, `omega`, `k`, `epsilon`) in `_generate_turbulence_fields` to ensure OpenFOAM can properly initialize its turbulence model, preventing silent immediate crashes.
- Fix logic applying fallback boundary conditions. `_apply_boundary_conditions` now injects `corkscrew` and `walls` as proper wall types into the generated patches to receive proper wall functions (`kqRWallFunction`, `epsilonWallFunction`, `nutkWallFunction`).
- Prevent the problematic `.*` catch-all fallback block from assigning `zeroGradient` to walls for turbulence fields, which previously caused `stochasticDispersionRAS` and other routines to crash with a `Floating point exception`.
- Convert `calculated` values on non-wall patches for turbulence fields to use `inletOutlet` boundaries with bounded defaults (`1e-6` and `1e-7`) to prevent division-by-zero on flow reversal.