### PR TITLE
Fix OpenFOAM size mismatch IO errors during sequential solver strategies

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -249,7 +249,7 @@ class FoamDriver:
         if self.use_container:
             cmd = "rm -rf processor*"
             if not processors_only:
-                cmd = "foamListTimes -rm && rm -rf processor*"
+                cmd = "foamListTimes -rm; rm -rf processor*"
 
             # Execute directly via run_command to let container handle permissions
             self.run_command(["/bin/bash", "-c", cmd], description="Cleaning up old results", ignore_error=True)


### PR DESCRIPTION
The OpenFOAM optimization loop was crashing during fallback solver strategies like `laminar` due to a fatal IO size mismatch error (`Size 198511 is not equal to the expected length 199011 file: processor0/2000/k/internalField`). 

The root cause was leftover processor directories from previous crashed or timed-out strategies (like `kOmegaSST` or `RNGkEpsilon`). The cleanup command used `&&` (`foamListTimes -rm && rm -rf processor*`), meaning if `foamListTimes -rm` returned an error (for instance, if there were no valid time directories to delete), the `rm -rf processor*` command was skipped entirely. This resulted in `reconstructPar` trying to piece together old processor boundaries with a fresh 0-time geometry.

This PR replaces the `&&` with a `;` (`foamListTimes -rm; rm -rf processor*`), ensuring that the containerized execution always forcefully removes the stale processor directories. Temporary script files used for local testing were also deleted.

---
*PR created automatically by Jules for task [5410424664913166404](https://jules.google.com/task/5410424664913166404) started by @LokiMetaSmith*