### PR TITLE
Fix CFD Solver Crashes and Geometry Meshing in Cyclone Filter

### DIFF
--- a/cyclone_filter_manifold.scad
+++ b/cyclone_filter_manifold.scad
@@ -74,7 +74,9 @@ module VortexFinder(solid = true) {
         if (solid) {
              cylinder(r=vortex_finder_radius, h=vortex_finder_length + 25, center=false);
         } else {
-             cylinder(r=vortex_finder_radius - wall_thickness, h=vortex_finder_length + 26, center=false); // Inner hole
+             // Extend slightly downwards to overlap with main fluid, ensuring explicit union
+             translate([0, 0, -1])
+             cylinder(r=vortex_finder_radius - wall_thickness, h=vortex_finder_length + 27, center=false); // Inner hole
         }
     }
 }

--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -2903,9 +2903,14 @@ boundaryField
         # Define monitor callback for early divergence detection
         def solver_monitor(line):
             line_lower = line.lower()
-            if "floating point exception" in line_lower or "segmentation fault" in line_lower:
+            if "floating point exception" in line_lower:
+                print("\n[Monitor] Floating point exception detected.")
+                return True
+            if "segmentation fault" in line_lower:
+                print("\n[Monitor] Segmentation fault detected.")
                 return True
             if "foam aborting" in line_lower or "foam fatal error" in line_lower:
+                print("\n[Monitor] OpenFOAM fatal error or abort detected.")
                 return True
 
             # Detect blowing up residuals


### PR DESCRIPTION
Fix OpenFOAM optimizations crashing immediately across all strategies due to non-manifold OpenSCAD fluid geometry and improve solver monitor abort logging to properly bubble up segfaults and floating point exceptions.

---
*PR created automatically by Jules for task [6432613039763256659](https://jules.google.com/task/6432613039763256659) started by @LokiMetaSmith*