### PR TITLE
Optimize OpenSCAD Geometry ($fn) limit

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -68,7 +68,7 @@ This file tracks planned enhancements and future work for the OpenAuto-CFD frame
 
 ## Phase 4: Upstream Geometry & Mesh Optimization
 To address the root cause of the numerical instabilities outlined in the technical report, the mesh quality must be improved at the source rather than relying solely on `foam_driver.py` workarounds.
-- [ ] **Optimize OpenSCAD Geometry ($fn):** Increase facet resolution (`$fn = 60` to `120`) on helical modules to prevent `snappyHexMesh` from snapping to artificial sharp edges and creating highly skewed cells.
+- [x] **Optimize OpenSCAD Geometry ($fn):** Increase facet resolution (`$fn = 60` to `120`) on helical modules to prevent `snappyHexMesh` from snapping to artificial sharp edges and creating highly skewed cells.
 - [ ] **Eliminate Non-Manifold Geometry (Epsilon Rule):** Add tiny overlaps (e.g., `+ 0.01mm`) to cutting tools in OpenSCAD before `union()` or `difference()` operations to eliminate zero-thickness shared edges.
 - [ ] **Smooth Internal Corners:** Add small chamfers or fillets to the root of the corkscrew blade to smooth the 90-degree internal corner, preventing the mesher from generating severely distorted cells at the singularity.
 - [ ] **Tune `snappyHexMeshDict` (Background Grid):** Lower `target_cell_size` so at least 4 to 5 base cells fit across the narrowest gap in the corkscrew channel before refinement.

--- a/config.scad
+++ b/config.scad
@@ -41,10 +41,10 @@ CUT_FOR_VISIBILITY = false;      // If true, cuts the model in half (removes Y>0
 
 // --- General & Precision ---
 _requested_high_res_fn = is_undef(high_res_fn) ? 200 : high_res_fn; // Fragment resolution for final renders ($fn). Higher values create smoother curves.
-if (_requested_high_res_fn > 60) {
-    echo("WARNING: high_res_fn capped at 60 for performance stability in WASM environment.");
+if (_requested_high_res_fn > 120) {
+    echo("WARNING: high_res_fn capped at 120 for performance stability in WASM environment.");
 }
-_actual_high_res_fn = min(_requested_high_res_fn, 60); // Cap resolution to prevent timeouts in WASM environment
+_actual_high_res_fn = min(_requested_high_res_fn, 120); // Cap resolution to prevent timeouts in WASM environment
 low_res_fn = is_undef(low_res_fn) ? 10 : low_res_fn;   // Fragment resolution for previews. Lower values provide faster previews.
 $fn = $preview ? low_res_fn : _actual_high_res_fn; // OpenSCAD automatically uses the appropriate value.
 

--- a/cyclone_filter_manifold.scad
+++ b/cyclone_filter_manifold.scad
@@ -16,7 +16,7 @@ dust_outlet_diameter = 25.0;
 wall_thickness = 2.0;
 
 // High resolution for rendering
-$fn = is_undef(high_res_fn) ? 60 : high_res_fn;
+$fn = is_undef(high_res_fn) ? 120 : high_res_fn;
 
 // Simulation flags
 GENERATE_CFD_VOLUME = is_undef(GENERATE_CFD_VOLUME) ? false : GENERATE_CFD_VOLUME;


### PR DESCRIPTION
This PR addresses an item from `TODO.md` under Phase 4: "Optimize OpenSCAD Geometry ($fn): Increase facet resolution (`$fn = 60` to `120`) on helical modules to prevent `snappyHexMesh` from snapping to artificial sharp edges and creating highly skewed cells."

The max resolution cap (`_actual_high_res_fn`) and warning thresholds have been updated to 120 in `config.scad`. `cyclone_filter_manifold.scad` was also updated to request `120` as the default high resolution. The `TODO.md` item has been marked as complete.

---
*PR created automatically by Jules for task [6310994125621562342](https://jules.google.com/task/6310994125621562342) started by @LokiMetaSmith*