### PR TITLE
Implement proactive Field Clamping

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -64,7 +64,7 @@ This file tracks planned enhancements and future work for the OpenAuto-CFD frame
     - [x] Dynamically adapt `fvSchemes` limiters based on mesh classification before running the solver.
 - [ ] **Phase 3: Full Orchestration System**
     - [ ] Implement multi-stage Retry Ladder: Try `RNG k-epsilon` -> degrade to `k-omega SST` -> fallback to `laminar`.
-    - [ ] Implement proactive Field Clamping: Sanitize fields to prevent them from becoming 0, NaN, or extremely small before the solver runs.
+    - [x] Implement proactive Field Clamping: Sanitize fields to prevent them from becoming 0, NaN, or extremely small before the solver runs.
 
 ## Phase 4: Upstream Geometry & Mesh Optimization
 To address the root cause of the numerical instabilities outlined in the technical report, the mesh quality must be improved at the source rather than relying solely on `foam_driver.py` workarounds.

--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -526,8 +526,8 @@ boundaryField
 
     def _sanitize_fields(self, zero_dir):
         """
-        Global invariant enforcer: ensure no turbulence fields fall to 0.
-        Particularly enforces nut >= 1e-7.
+        Global invariant enforcer: ensure no turbulence fields fall to 0, NaN, or extremely small values.
+        Particularly enforces nut >= 1e-7 and k, epsilon, omega >= 1e-6.
         """
         for field in ["k", "epsilon", "omega", "nut"]:
             field_path = os.path.join(zero_dir, field)
@@ -537,20 +537,40 @@ boundaryField
             with open(field_path, 'r') as f:
                 content = f.read()
 
-            default_val = "1e-7" if field == "nut" else "1e-6"
+            default_val_str = "1e-7" if field == "nut" else "1e-6"
+            default_val = float(default_val_str)
+
+            def clamp_value(match):
+                prefix = match.group(1)
+                val_str = match.group(2)
+                suffix = match.group(3)
+
+                if val_str.lower() == 'nan':
+                    return f"{prefix}{default_val_str}{suffix}"
+
+                try:
+                    val = float(val_str)
+                    if val < default_val:
+                        return f"{prefix}{default_val_str}{suffix}"
+                except ValueError:
+                    pass
+
+                return match.group(0)
 
             # Sanitize internalField
             content = re.sub(
-                r"internalField\s+uniform\s+0(\.0*)?\s*;",
-                f"internalField   uniform {default_val};",
-                content
+                r"(internalField\s+uniform\s+)([+-]?\d*\.?\d+(?:[eE][+-]?\d+)?|NaN)(\s*;)",
+                clamp_value,
+                content,
+                flags=re.IGNORECASE
             )
 
-            # Sanitize boundary values that are exactly 0
+            # Sanitize boundary values
             content = re.sub(
-                r"value\s+uniform\s+0(\.0*)?\s*;",
-                f"value           uniform {default_val};",
-                content
+                r"(value\s+uniform\s+)([+-]?\d*\.?\d+(?:[eE][+-]?\d+)?|NaN)(\s*;)",
+                clamp_value,
+                content,
+                flags=re.IGNORECASE
             )
 
             with open(field_path, 'w') as f:


### PR DESCRIPTION
Implemented the TODO item to sanitize and clamp OpenFOAM initialization fields to prevent them from becoming exactly 0, NaN, or extremely small values which could crash the solver. Updated the regex in `_sanitize_fields` to capture floating point numbers (including scientific notation) and NaN, clamping them if they fall below the default thresholds (`1e-7` for `nut`, `1e-6` for `k`, `epsilon`, `omega`). Updated `TODO.md` to reflect task completion.

---
*PR created automatically by Jules for task [11018709138329130916](https://jules.google.com/task/11018709138329130916) started by @LokiMetaSmith*