### PR TITLE
Fix OpenSCAD CFD geometry and OpenFOAM meshing parameters

### DIFF
--- a/corkscrewFilter/system/snappyHexMeshDict.template
+++ b/corkscrewFilter/system/snappyHexMeshDict.template
@@ -53,7 +53,11 @@ castellatedMeshControls
         {% for geom in geometries %}
         {{ geom.name }}
         {
+            {% if geom.name == "corkscrew" %}
+            level (4 5);
+            {% else %}
             level {{ geom.level }};
+            {% endif %}
             {% if geom.patch_info %}
             patchInfo
             {
@@ -87,10 +91,10 @@ addLayersControls
     finalLayerThickness 0.3;
     minThickness 0.1;
     nGrow 0;
-    featureAngle 130;
-    maxFaceThicknessRatio 0.5;
-    maxThicknessToMedialRatio 0.3;
-    minMedialAxisAngle 90;
+    featureAngle 160;
+    maxFaceThicknessRatio 0.6;
+    maxThicknessToMedialRatio 0.6;
+    minMedialAxisAngle 130;
     nBufferCellsNoExtrude 0;
     nLayerIter 50;
     nSmoothSurfaceNormals 1;

--- a/modules/assemblies.scad
+++ b/modules/assemblies.scad
@@ -97,9 +97,9 @@ module ModularFilterAssembly(tube_id, total_length) {
 
                         // Slits
                         if (slit_type == "simple") {
-                            SimpleSlitCutter(h + 0.02, rate * (h + 0.02), 2 * (helix_path_radius_mm + safe_profile_radius), 1, offset_angle=0);
+                            SimpleSlitCutter(h + 0.04, rate * (h + 0.04), 2 * (helix_path_radius_mm + safe_profile_radius), 1, offset_angle=0);
                         } else if (slit_type == "ramped") {
-                            RampedSlitKnife(h + 0.02, rate * (h + 0.02), 2 * (helix_path_radius_mm + safe_profile_radius), 1, offset_angle=0);
+                            RampedSlitKnife(h + 0.04, rate * (h + 0.04), 2 * (helix_path_radius_mm + safe_profile_radius), 1, offset_angle=0);
                         }
                     }
                 } else {
@@ -114,7 +114,7 @@ module ModularFilterAssembly(tube_id, total_length) {
                             cylinder(d = spacer_od, h = h + 0.02, center = true); // Add overlap
 
                             // Cut the helical void
-                            Corkscrew(h + 0.04, rate * (h + 0.04), void = true);
+                            Corkscrew(h + 0.06, rate * (h + 0.06), void = true);
 
                             union(){
                                 OringGroove_OD_Cutter(spacer_od, oring_cross_section_mm);

--- a/modules/core.scad
+++ b/modules/core.scad
@@ -15,10 +15,18 @@
  * profile_r: The base radius of the circular profile before it's scaled into an ellipse.
  */
 module HelicalShape(h, twist, path_r, profile_r) {
+    $fn = $preview ? 32 : 128;
     linear_extrude(height = h, center = true, convexity = 10, twist = twist) {
-        translate([path_r, 0, 0]) {
-            scale([1, helix_profile_scale_ratio]) {
-                circle(r = profile_r);
+        // Create the main elliptical profile
+        // and a fillet that connects it smoothly to the central axis (r=0)
+        union() {
+            translate([path_r, 0, 0]) {
+                scale([1, helix_profile_scale_ratio]) {
+                    circle(r = profile_r);
+                }
+            }
+            translate([path_r / 2, 0, 0]) {
+                square([path_r, profile_r], center=true);
             }
         }
     }
@@ -55,9 +63,15 @@ module Corkscrew(h, twist, void = false) {
  * inner_r:   The base radius of the inner circular profile.
  */
 module HollowHelicalShape(h, twist, path_r, outer_r, inner_r) {
+    $fn = $preview ? 32 : 128;
     linear_extrude(height = h, center = true, convexity = 10, twist = twist) {
         difference() {
-            translate([path_r, 0, 0]) scale([1, helix_profile_scale_ratio]) circle(r = outer_r);
+            union() {
+                translate([path_r, 0, 0]) scale([1, helix_profile_scale_ratio]) circle(r = outer_r);
+                translate([path_r / 2, 0, 0]) {
+                    square([path_r, outer_r], center=true);
+                }
+            }
             translate([path_r, 0, 0]) scale([1, helix_profile_scale_ratio]) circle(r = inner_r);
         }
     }

--- a/modules/cutters.scad
+++ b/modules/cutters.scad
@@ -153,7 +153,8 @@ module CorkscrewSlitKnife(twist, depth, num_bins) {
         j = -num_bins/2 + i;
         rotate([0, 0, -yrot * j])
         translate([0, 0, j * de])
-            RampedKnifeShape(slit_axial_length_mm, twist / depth * slit_axial_length_mm, helix_path_radius_mm, helix_profile_radius_mm);
+            // Added 0.02 epsilon to length for clean cuts
+            RampedKnifeShape(slit_axial_length_mm + 0.02, twist / depth * (slit_axial_length_mm + 0.02), helix_path_radius_mm, helix_profile_radius_mm);
     }
 }
 

--- a/render_cfd.scad
+++ b/render_cfd.scad
@@ -1,0 +1,1 @@
+include <corkscrew.scad>

--- a/test/test_foam_metrics.py
+++ b/test/test_foam_metrics.py
@@ -15,6 +15,7 @@ class TestFoamMetrics(unittest.TestCase):
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()
         self.driver = FoamDriver(self.test_dir)
+        os.makedirs(os.path.dirname(self.driver.log_file), exist_ok=True)
         # Create dummy log file
         with open(self.driver.log_file, 'w') as f:
             f.write("Dummy Log\n")
@@ -25,7 +26,7 @@ class TestFoamMetrics(unittest.TestCase):
     def test_parse_particle_collector(self):
         # Setup directory structure for patchPostProcessing
         # Path: case/postProcessing/kinematicCloud/patchPostProcessing1/*/patchPostProcessing1.dat
-        pp_dir = os.path.join(self.test_dir, "postProcessing", "kinematicCloud", "patchPostProcessing1", "0")
+        pp_dir = os.path.join(self.driver.case_dir, "postProcessing", "kinematicCloud", "patchPostProcessing1", "0")
         os.makedirs(pp_dir)
 
         dat_file = os.path.join(pp_dir, "patchPostProcessing1.dat")


### PR DESCRIPTION
Resolves CFD simulation crashes by fixing OpenSCAD STL generation to be fully manifold and sufficiently high-resolution while tuning OpenFOAM's `snappyHexMesh` configurations to build high-quality meshes over the newly smoothed, filleted internal corners.

---
*PR created automatically by Jules for task [16385610528562760904](https://jules.google.com/task/16385610528562760904) started by @LokiMetaSmith*