### PR TITLE
Add .env support and local Ollama failover integration

### DIFF
--- a/optimizer/check_models.py
+++ b/optimizer/check_models.py
@@ -1,5 +1,8 @@
 import os
+from dotenv import load_dotenv
 from llm_agent import LLMAgent
+
+load_dotenv()
 
 def list_models():
     print("Checking available models from configured providers...")
@@ -14,6 +17,7 @@ def list_models():
         print("Please set one of the following environment variables:")
         print("  - GEMINI_API_KEY")
         print("  - OPENAI_API_KEY (and optionally OPENAI_BASE_URL)")
+        print("  - or ensure Ollama is running locally (http://localhost:11434)")
         return
 
     # Use the agent to list models

--- a/optimizer/llm_agent.py
+++ b/optimizer/llm_agent.py
@@ -5,7 +5,12 @@ import random
 import mimetypes
 import time
 import base64
+import urllib.request
+import urllib.error
+from dotenv import load_dotenv
 from typing import Dict, List, Any, Union, Tuple
+
+load_dotenv()
 
 # Attempt imports for providers
 try:
@@ -118,6 +123,55 @@ class GoogleGenAIProvider(LLMProvider):
                     models.append(m.name)
         except Exception as e:
             print(f"Error listing Google models: {e}")
+        return models
+
+
+class OllamaProvider(LLMProvider):
+    def __init__(self, host: str = "http://localhost:11434", model_name: str = "llama3"):
+        self.host = host.rstrip('/')
+        self.model_name = model_name
+
+    def get_name(self) -> str:
+        return f"Ollama Local ({self.host}) - Model: {self.model_name}"
+
+    def _encode_image(self, image_path: str) -> str:
+        with open(image_path, "rb") as image_file:
+            return base64.b64encode(image_file.read()).decode('utf-8')
+
+    def generate(self, prompt: str, image_paths: List[str] = None) -> str:
+        url = f"{self.host}/api/generate"
+        payload = {
+            "model": self.model_name,
+            "prompt": prompt,
+            "stream": False
+        }
+
+        if image_paths:
+            images = []
+            for path in image_paths:
+                images.append(self._encode_image(path))
+            payload["images"] = images
+
+        data = json.dumps(payload).encode('utf-8')
+        req = urllib.request.Request(url, data=data, headers={'Content-Type': 'application/json'})
+
+        try:
+            with urllib.request.urlopen(req) as response:
+                result = json.loads(response.read().decode('utf-8'))
+                return result.get("response", "")
+        except urllib.error.URLError as e:
+            raise Exception(f"Ollama connection error: {e}")
+
+    def list_models(self) -> List[str]:
+        url = f"{self.host}/api/tags"
+        models = []
+        try:
+            with urllib.request.urlopen(url) as response:
+                result = json.loads(response.read().decode('utf-8'))
+                for model in result.get("models", []):
+                    models.append(model.get("name"))
+        except Exception as e:
+            print(f"Error listing Ollama models: {e}")
         return models
 
 
@@ -246,9 +300,23 @@ class LLMAgent:
         elif not openai and (openai_key or openai_base):
             print("Warning: OPENAI_API_KEY/BASE_URL present but openai lib missing.")
 
+        # 3. Ollama Local Setup
+        ollama_host = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+        ollama_model = os.environ.get("OLLAMA_MODEL", "llama3")
+        try:
+            # Check if Ollama is running
+            req = urllib.request.Request(f"{ollama_host.rstrip('/')}/api/tags")
+            with urllib.request.urlopen(req, timeout=2) as response:
+                if response.status == 200:
+                    p = OllamaProvider(host=ollama_host, model_name=ollama_model)
+                    self.providers.append(p)
+                    # print(f"Registered provider: {p.get_name()}")
+        except Exception:
+            pass # Ollama not running or reachable, skip
+
         if not self.providers:
-            print("Warning: No LLM providers available (Missing Keys or Libraries). LLM features will be disabled.")
-            print("To enable, set GEMINI_API_KEY or OPENAI_API_KEY/OPENAI_BASE_URL.")
+            print("Warning: No LLM providers available (Missing Keys, Libraries, or Local Endpoint). LLM features will be disabled.")
+            print("To enable, set GEMINI_API_KEY, OPENAI_API_KEY, or start a local Ollama instance.")
 
     def _generate(self, prompt: str, image_paths: List[str] = None) -> str:
         """Iterates through providers until one succeeds."""

--- a/optimizer/main.py
+++ b/optimizer/main.py
@@ -8,6 +8,7 @@ import hashlib
 import sys
 import uuid
 import yaml
+from dotenv import load_dotenv
 from scad_driver import ScadDriver
 from foam_driver import FoamDriver
 from llm_agent import LLMAgent
@@ -32,6 +33,7 @@ def get_params_hash(params):
     return hashlib.md5(s.encode('utf-8')).hexdigest()
 
 def main():
+    load_dotenv()
     parser = argparse.ArgumentParser(description="Generative AI Optimizer for Config-Driven Workflows")
     parser.add_argument("config_file", type=str, help="Path to the problem definition YAML file")
     parser.add_argument("--iterations", type=str, default="5", help="Number of iterations (int), or 'inf'/'infinite'/-1 for infinite loop")

--- a/optimizer/requirements.txt
+++ b/optimizer/requirements.txt
@@ -10,3 +10,4 @@ openai
 pytest
 PyYAML
 Jinja2
+python-dotenv

--- a/optimizer/verify_llm.py
+++ b/optimizer/verify_llm.py
@@ -1,6 +1,9 @@
 import os
 import sys
+from dotenv import load_dotenv
 from llm_agent import LLMAgent
+
+load_dotenv()
 
 def main():
     print("Verifying LLM Connection...")
@@ -14,6 +17,7 @@ def main():
         print("Please set one of the following:")
         print("  - GEMINI_API_KEY (for Google Gemini)")
         print("  - OPENAI_API_KEY (and optionally OPENAI_BASE_URL for Local LLMs)")
+        print("  - or ensure Ollama is running locally (http://localhost:11434)")
         sys.exit(1)
 
     print(f"\nConfigured Providers:")

--- a/start_optimization.sh
+++ b/start_optimization.sh
@@ -84,12 +84,41 @@ if [ "$HAS_NODE" = false ]; then
      print_warning "Node.js not found. Visualization (PNG) generation will be disabled."
 fi
 
-# 2. Check API Key
-if [ -z "$GEMINI_API_KEY" ] && [ -z "$OPENAI_API_KEY" ] && [ -z "$OPENAI_BASE_URL" ]; then
+# 2. Check API Key and Endpoints
+if [ -f ".env" ]; then
+    echo "Loading variables from .env file..."
+    set -a
+    source .env
+    set +a
+fi
+
+LLM_DETECTED=false
+LLM_INFO=""
+
+if [ -n "$GEMINI_API_KEY" ]; then
+    LLM_DETECTED=true
+    LLM_INFO="$LLM_INFO Gemini"
+fi
+
+if [ -n "$OPENAI_API_KEY" ] || [ -n "$OPENAI_BASE_URL" ]; then
+    LLM_DETECTED=true
+    LLM_INFO="$LLM_INFO OpenAI-Compatible"
+fi
+
+# Check for local Ollama
+if command -v curl &> /dev/null && curl -s -f http://localhost:11434/api/tags > /dev/null 2>&1 || [ -n "$OLLAMA_HOST" ]; then
+    LLM_DETECTED=true
+    LLM_INFO="$LLM_INFO Ollama"
+fi
+
+if [ "$LLM_DETECTED" = true ]; then
+    echo "Detected LLM Providers:$LLM_INFO"
+else
     if [[ "$*" == *"--no-llm"* ]] || [ "$NON_INTERACTIVE" == "1" ]; then
-        print_warning "No LLM API Key found. Proceeding in dry-run/random mode."
+        print_warning "No LLM API Key or local endpoint found. Proceeding in dry-run/random mode."
     else
-        print_warning "No LLM API Key found (GEMINI_API_KEY, OPENAI_API_KEY, or OPENAI_BASE_URL)."
+        print_warning "No LLM API Key or local endpoint found."
+        echo "Please set GEMINI_API_KEY, OPENAI_API_KEY, OPENAI_BASE_URL, or start a local Ollama instance."
         echo "The optimizer will run in 'dry-run' or 'random' mode without LLM guidance."
         read -p "Do you want to continue without LLM? (y/n) " -n 1 -r
         echo


### PR DESCRIPTION
This pull request addresses the user request to support `.env` files for managing API keys and explicitly integrating a failover to a locally running Ollama instance when executing the optimization scripts.

Changes included:
*   Added `python-dotenv` to `requirements.txt` to enable python scripts to automatically pull from local `.env` files.
*   Updated `start_optimization.sh` to properly handle and parse local `.env` files (`set -a; source .env; set +a`), and improved the feedback to the console so that it appropriately recognizes `Ollama` running on port 11434.
*   Implemented `OllamaProvider` in `llm_agent.py` to seamlessly interact with Ollama via `urllib` without needing external wrappers, handling image conversion when requested.
*   Updated checking scripts (`check_models.py`, `verify_llm.py`) to reflect Ollama support.
*   Passed all existing parameter validation unit tests successfully.

---
*PR created automatically by Jules for task [13182348211445692894](https://jules.google.com/task/13182348211445692894) started by @LokiMetaSmith*