### PR TITLE
Fix trimesh nondegenerate_faces kwargs in scad_driver

### DIFF
--- a/optimizer/scad_driver.py
+++ b/optimizer/scad_driver.py
@@ -361,7 +361,7 @@ class ScadDriver:
                 mesh.process()
 
                 # Explicitly remove degenerate faces (area check). Use 1e-14 to support scaled-to-meters meshes
-                mesh.update_faces(mesh.nondegenerate_faces(area_threshold=1e-14))
+                mesh.update_faces(mesh.nondegenerate_faces(height=1e-14))
 
                 if len(mesh.faces) == 0:
                     return None


### PR DESCRIPTION
Fix trimesh nondegenerate_faces kwargs in scad_driver

Trimesh version > 4.0 replaced the `area_threshold` argument with `height` in the `nondegenerate_faces()` method. This updates `optimizer/scad_driver.py` to use `height=1e-14` instead to prevent a `TypeError` and crash during mesh bounds calculation and scaling.

---
*PR created automatically by Jules for task [14191413467979433801](https://jules.google.com/task/14191413467979433801) started by @LokiMetaSmith*