### PR TITLE
Fix snappyHexMesh missing corkscrew patch definition

### DIFF
--- a/corkscrewFilter/system/snappyHexMeshDict.template
+++ b/corkscrewFilter/system/snappyHexMeshDict.template
@@ -50,7 +50,7 @@ castellatedMeshControls
 
     refinementSurfaces
     {
-        {% for geom in geometries %}
+        {% for geom in unique_geometries %}
         {{ geom.name }}
         {
             {% if geom.name == "corkscrew" %}

--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -1908,6 +1908,9 @@ cloudFunctions
         physics_boundaries = self.config.get('physics', {}).get('boundaries', {})
 
         geometries = []
+        unique_geometries = []
+        seen_patch_names = set()
+
         for key, filename in stl_assets.items():
             patch_name = "corkscrew"
             if key in physics_boundaries:
@@ -1923,9 +1926,13 @@ cloudFunctions
                 "filename": filename,
                 "name": patch_name,
                 "level": "(3 4)" if patch_name == "corkscrew" else "(1 1)",
-                "patch_info": key in physics_boundaries or key in ["inlet", "outlet"]
+                "patch_info": key in physics_boundaries or key in ["inlet", "outlet", "wall", "fluid"]
             }
             geometries.append(geom)
+
+            if patch_name not in seen_patch_names:
+                unique_geometries.append(geom)
+                seen_patch_names.add(patch_name)
 
         template_path = os.path.join(self.case_dir, "system", "snappyHexMeshDict.template")
         shm_path = os.path.join(self.case_dir, "system", "snappyHexMeshDict")
@@ -1963,6 +1970,7 @@ cloudFunctions
         content = template.render(
             add_layers=add_layers,
             geometries=geometries,
+            unique_geometries=unique_geometries,
             location_in_mesh=location_in_mesh
         )
 


### PR DESCRIPTION
**Problem:**
During mesh generation, the validation step was failing with `Meshing failed verification: missing or empty inlet/outlet patches. Patch 'corkscrew' not found in boundary file.`. This happened because the script did not add a `patchInfo` definition inside the `refinementSurfaces` block for the `corkscrew_fluid.stl` geometry. Consequently, `snappyHexMesh` would snap the geometry but group its resulting faces into the `defaultFaces` patch, causing subsequent operations (`topoSet`, solver execution) to fail due to the missing `corkscrew` patch.

**Solution:**
1. Modified `_generate_snappyHexMeshDict` in `optimizer/foam_driver.py` so that STLs associated with the keys `"fluid"` and `"wall"` properly receive `patch_info: True`.
2. Created a deduplicated list, `unique_geometries`, from the geometry inputs (since both `corkscrew_fluid.stl` and `wall.stl` map to the patch name `corkscrew`) and passed it to the Jinja template. This prevents OpenFOAM from throwing duplicate key errors in the `refinementSurfaces` dictionary.
3. Updated `corkscrewFilter/system/snappyHexMeshDict.template` to iterate over `unique_geometries` in its `refinementSurfaces` block.

**Testing:**
Ran Pytest test suite successfully with no regressions introduced. Tested driver mesh generation functionality directly.

---
*PR created automatically by Jules for task [10062701487308215827](https://jules.google.com/task/10062701487308215827) started by @LokiMetaSmith*