### PR TITLE
Update Podman machine memory configuration to 32GB in repair_podman.ps1

### DIFF
--- a/repair_podman.ps1
+++ b/repair_podman.ps1
@@ -231,7 +231,7 @@ if (Get-Command "podman" -ErrorAction SilentlyContinue) {
 
 # 11. Initialize and start a fresh Podman machine
 Write-Host "Initializing a fresh Podman machine..." -ForegroundColor Cyan
-podman machine init --memory 8192
+podman machine init --memory 32768
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Failed to initialize Podman machine."
     exit 1
@@ -242,6 +242,12 @@ podman machine start
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Failed to start Podman machine."
     exit 1
+}
+
+Write-Host "Configuring Podman machine resources via setup_machine.py..." -ForegroundColor Cyan
+python optimizer/setup_machine.py --memory 32768
+if ($LASTEXITCODE -ne 0) {
+    Write-Warning "setup_machine.py failed, but continuing..."
 }
 
 # 12. Verify functionality


### PR DESCRIPTION
Updated `repair_podman.ps1` to configure the Podman machine to 32GB instead of 8GB by modifying `podman machine init` and calling `setup_machine.py`.

---
*PR created automatically by Jules for task [11188666401104028454](https://jules.google.com/task/11188666401104028454) started by @LokiMetaSmith*