### PR TITLE
fix: Increase default Podman VM memory limit to 16GB

### DIFF
--- a/optimizer/setup_machine.py
+++ b/optimizer/setup_machine.py
@@ -82,7 +82,7 @@ def resize_podman_machine(memory_mb, cpus=None, machine_name="podman-machine-def
 
 def main():
     parser = argparse.ArgumentParser(description="Configure Podman Machine Resources")
-    parser.add_argument("--memory", type=int, default=8192, help="Target memory in MB (default: 8192)")
+    parser.add_argument("--memory", type=int, default=16384, help="Target memory in MB (default: 16384)")
     parser.add_argument("--cpus", type=int, help="Target CPU count")
     parser.add_argument("--machine", type=str, default="podman-machine-default", help="Machine name (default: podman-machine-default)")
     parser.add_argument("-y", "--yes", action="store_true", help="Automatically confirm all prompts")

--- a/optimizer/simulation_runner.py
+++ b/optimizer/simulation_runner.py
@@ -226,7 +226,7 @@ def run_simulation(scad_driver, foam_driver, params, output_stl_name="corkscrew_
 
                     if ram_gb < 7.5 and foam_driver.container_tool == "podman":
                         print(f"Tip: Your container memory is low ({ram_gb:.1f}GB < 8GB). You can increase it by running:")
-                        print("     python optimizer/setup_machine.py --memory 8192")
+                        print("     python optimizer/setup_machine.py --memory 16384")
 
                 except Exception as e:
                     print(f"Warning: Failed to detect memory ({e}). Using default.")

--- a/repair_podman.ps1
+++ b/repair_podman.ps1
@@ -231,7 +231,7 @@ if (Get-Command "podman" -ErrorAction SilentlyContinue) {
 
 # 11. Initialize and start a fresh Podman machine
 Write-Host "Initializing a fresh Podman machine..." -ForegroundColor Cyan
-podman machine init --memory 8192
+podman machine init --memory 16384
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Failed to initialize Podman machine."
     exit 1


### PR DESCRIPTION
Increases the default Podman machine memory limit to 16GB to prevent OOM errors during CFD meshing.

---
*PR created automatically by Jules for task [11656656908230559119](https://jules.google.com/task/11656656908230559119) started by @LokiMetaSmith*