### PR TITLE
Fix geometry name collision in snappyHexMeshDict generation

### DIFF
--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -1912,15 +1912,18 @@ cloudFunctions
         seen_patch_names = set()
 
         for key, filename in stl_assets.items():
-            patch_name = "corkscrew"
-            if key in physics_boundaries:
-                patch_name = key
-            elif key == "wall":
+            if key == "fluid":
                 patch_name = "corkscrew"
+            elif key == "wall":
+                patch_name = "wall"
+            elif key in physics_boundaries:
+                patch_name = key
             elif key == "inlet":
                 patch_name = "inlet"
             elif key == "outlet":
                 patch_name = "outlet"
+            else:
+                patch_name = key
 
             geom = {
                 "filename": filename,


### PR DESCRIPTION
Fixes a bug where meshing fails because the inlet/outlet patches are missing.

The actual cause was that in `snappyHexMeshDict`, both the `fluid` (`corkscrew_fluid.stl`) and `wall` (`wall.stl`) geometry assets were mapped to the same patch name `"corkscrew"`. OpenFOAM processes the geometry block as a hash map, meaning the second entry completely overrode the first. This caused `snappyHexMesh` to fail to see the internal complex helix geometry, leading to missing patches because no internal faces were correctly generated.

This commit updates `optimizer/foam_driver.py` to assign `"corkscrew"` to `fluid` and `"wall"` to `wall`, eliminating the collision.

---
*PR created automatically by Jules for task [13031484958127772319](https://jules.google.com/task/13031484958127772319) started by @LokiMetaSmith*