### PR TITLE
Fix snappyHexMesh missing corkscrew patch by extracting features dynamically

### DIFF
--- a/corkscrewFilter/system/snappyHexMeshDict.template
+++ b/corkscrewFilter/system/snappyHexMeshDict.template
@@ -42,10 +42,12 @@ castellatedMeshControls
 
     features
     (
+        {% for geom in unique_geometries %}
         {
-            file "corkscrew_fluid.eMesh";
+            file "{{ geom.filename.replace('.stl', '.eMesh') }}";
             level 1;
         }
+        {% endfor %}
     );
 
     refinementSurfaces

--- a/optimizer/foam_driver.py
+++ b/optimizer/foam_driver.py
@@ -1906,6 +1906,48 @@ cloudFunctions
                     f.write(f"\nError renaming scaled mesh: {e}\n")
             return False
 
+    def _generate_surfaceFeatureExtractDict(self, unique_geometries):
+        """
+        Generates system/surfaceFeatureExtractDict using Jinja2 or direct formatting.
+        """
+        template_str = """/*--------------------------------*- C++ -*----------------------------------*\
+| =========                 |                                                 |
+| \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox           |
+|  \\    /   O peration     | Version:  v2512                                 |
+|   \\  /    A nd           | Website:  www.openfoam.com                      |
+|    \\/     M anipulation  |                                                 |
+\*---------------------------------------------------------------------------*/
+FoamFile
+{
+    version     2.0;
+    format      ascii;
+    class       dictionary;
+    location    "system";
+    object      surfaceFeatureExtractDict;
+}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+"""
+        for geom in unique_geometries:
+            filename = geom["filename"]
+            template_str += f"""{filename}
+{{
+    extractionMethod    extractFromSurface;
+
+    extractFromSurfaceCoeffs
+    {{
+        includedAngle   150;
+    }}
+
+    writeObj        true;
+}}
+
+"""
+        template_str += "// ************************************************************************* //\n"
+
+        with open(os.path.join(self.case_dir, "system", "surfaceFeatureExtractDict"), 'w') as f:
+            f.write(template_str)
+
     def _generate_snappyHexMeshDict(self, stl_assets, add_layers=True):
         """
         Updates system/snappyHexMeshDict to include all assets as geometry/patches using Jinja2.
@@ -1943,6 +1985,8 @@ cloudFunctions
             if patch_name not in seen_patch_names:
                 unique_geometries.append(geom)
                 seen_patch_names.add(patch_name)
+
+        self._generate_surfaceFeatureExtractDict(unique_geometries)
 
         template_path = os.path.join(self.case_dir, "system", "snappyHexMeshDict.template")
         shm_path = os.path.join(self.case_dir, "system", "snappyHexMeshDict")


### PR DESCRIPTION
This pull request fixes a meshing failure where `snappyHexMesh` could not resolve patches, such as 'corkscrew', 'inlet', and 'outlet', returning an error that boundary patches were missing and failing verification.

The root cause was that `surfaceFeatureExtractDict` was entirely hardcoded to only look for `corkscrew_fluid.stl`, and `snappyHexMeshDict.template`'s `features` block was similarly hardcoded to only look for `corkscrew_fluid.eMesh`. The fix makes both dynamic by dynamically rendering the dictionaries using `unique_geometries` to cover all active physical STL layers being processed.

---
*PR created automatically by Jules for task [3581026959954309517](https://jules.google.com/task/3581026959954309517) started by @LokiMetaSmith*